### PR TITLE
A First Draft of a Functional Simulations Tab

### DIFF
--- a/app/methods/testarea.R
+++ b/app/methods/testarea.R
@@ -205,3 +205,48 @@ o_sims
 # add error for number of doses in true_dlt_ss being different to num_doses!
 # or programmatically make it impossible? reactibve table input?
 
+############### Testing Simulation Ouputs ###################
+
+## Testing conditions approach:
+
+observeEvent(input$submit, {
+## List of possible selections - these will be TRUE or FALSE depending on the user's input
+# Model
+selected_tpt <- {"3+3" %in% input$simulation_design_selection_input}
+selected_crm <- {"crm" %in% input$simulation_design_selection_input}
+
+#Scenario (to do later)
+
+# Metric
+selected_participant <- {"% participants treated at dose" %in% input$metric_selection_input}
+selected_mtd <- {"% times dose was selected as MTD" %in% input$metric_selection_input}
+selected_accuracy <- {"Accuracy" %in% input$metric_selection_input}
+selected_duration <- {"Duration" %in% input$metric_selection_input}
+selected_overdose <- {"Overdosing" %in% input$metric_selection_input}
+
+tpt_sim <- sim_tpt(5, 0.55, 86, 3, 1000, c(0.05, 0.15, 1/3, 0.5, 0.8), 12345)
+# crm_sim <- sim_crm()
+
+datasets <- list(tpt_participant = tpt_sim$treated_tab,
+                 tpt_mtd = tpt_sim$selection_tab,
+                 tpt_accuracy = tpt_sim$mean_accuracy,
+                 tpt_duration = tpt_sim$mean_length,
+                 tpt_overdose = tpt_sim$mean_overdose#,
+                 # crm_participant = crm_sim$treated_tab,
+                 # crm_mtd = crm_sim$selection_tab,
+                 # crm_accuracy = crm_sim$mean_accuracy,
+                 # crm_duration = crm_sim$mean_length,
+                 # crm_overdose = crm_sim$mean_overdose
+                 )
+
+  model_options <- cbind(rep(selected_tpt, 5)#,
+                         #rep(selected_crm, 5)
+                         )
+  # scenario_options <- c() # To be implemented later
+  metric_options <- rep(c(selected_participant, selected_mtd, selected_accuracy, selected_duration, selected_overdose), 1) # replace with 2) when crm is added
+
+  condition_map <- as.data.frame(cbind(model_options, metric_options, datasets))
+  filtered_datasets <- df[condition_map$model_options == TRUE & condition_map$metric_options == TRUE, "datasets"]
+
+  output$scen_sim_output <- lappy(list(filtered_datasets, renderDT()))
+  })

--- a/app/modules/trial_design/global.R
+++ b/app/modules/trial_design/global.R
@@ -118,19 +118,19 @@ treatedpct$tpt <- treated$tpt / sum(treated$tpt)
 
 # coerce into selection table
 
-selection_df$tpt <- data.frame(selection$tpt)
+selection_df$tpt <- data.frame(selection$tpt*100) # Converting to %
 
 selection_tab$tpt <- rbind(t(selection_df$tpt), c(NA,true_dlt_ss))
 
-rownames(selection_tab$tpt) <- c("Proportion of Simulations Dose Selected by Model", "True Toxicity Probabilities")
+rownames(selection_tab$tpt) <- c("% of Simulations that Chose Dose as MTD", "True Toxicity Probabilities")
 
 # coerce into treatment table
 
-treatedpct_df$tpt <- data.frame(treatedpct$tpt)
+treatedpct_df$tpt <- data.frame(treatedpct$tpt*100) # Converting to %
 
 treatment_tab$tpt <- rbind(t(treatedpct_df$tpt),true_dlt_ss)
 
-rownames(treatment_tab$tpt) <- c("Proportion of Patients Treated by Model", "True Toxicity Probabilities")
+rownames(treatment_tab$tpt) <- c("% of Patients Treated at Dose", "True Toxicity Probabilities")
 
 # i) accuracy
 
@@ -250,19 +250,19 @@ treatedpct$crm <- treated$crm / sum(treated$crm)
 
 # coerce into table
 
-selection_df$crm <- data.frame(selection$crm)
-treatedpct_df$crm <- data.frame(treatedpct$crm)
+selection_df$crm <- data.frame(selection$crm*100) # Converting to %
+treatedpct_df$crm <- data.frame(treatedpct$crm*100) # Converting to %
 selection_tab$crm <- rbind(t(selection_df$crm), c(NA,true_dlt_ss))
 
-rownames(selection_tab$crm) <- c("Dose Selected by Model", "True Toxicity Probabilities")
+rownames(selection_tab$crm) <- c("% of Simulations that Chose Dose as MTD", "True Toxicity Probabilities")
 
 # coerce into treatment table
 
-treatedpct_df$crm <- data.frame(treatedpct$crm)
+treatedpct_df$crm <- data.frame(treatedpct$crm*100) # Converting to %
 
 treatment_tab$crm <- rbind(t(treatedpct_df$crm),true_dlt_ss)
 
-rownames(treatment_tab$crm) <- c("Patients Treated by Model", "True Toxicity Probabilities")
+rownames(treatment_tab$crm) <- c("% of Patients Treated at Dose", "True Toxicity Probabilities")
 
 # i) accuracy
 

--- a/app/modules/trial_design/global.R
+++ b/app/modules/trial_design/global.R
@@ -51,7 +51,7 @@ questions <- dummy_data
 
 ### This is a rewrite of the basesim.r file as a set of functions that can be used reactively to simulate data.
 
-sim_tpt <- function(n_doses, ttl, max_n, start_dose, n_sims, true_dlt_ss, current_seed) {
+sim_tpt <- function(n_doses, ttl, max_n, start_dose, n_sims, true_dlt_ss, skip_deesc, current_seed) {
 
  ## Example inputs taken from the original basesim.r file
  # n_doses <- 5
@@ -91,7 +91,7 @@ mean_length <- list()
   model <- list()
   
   # Set parameters
-  tpt_allow_deesc <- TRUE
+  tpt_allow_deesc <- skip_deesc
   
   # Create the model
   model$tpt <- escalation::get_three_plus_three(num_doses = n_doses, 

--- a/app/modules/trial_design/global.R
+++ b/app/modules/trial_design/global.R
@@ -167,7 +167,11 @@ output <- list(
 sim_crm <- function(n_doses, ttl, max_n, start_dose, n_sims, true_dlt_ss, skeleton, prior_var,
                     skip_esc, skip_deesc, stop_tox_x, stop_tox_y, stop_n_mtd) {
 
-  
+  # Failsafe for when n_doses does not match the length of skeleton
+  if (length(skeleton) != n_doses) {
+    stop("The length of the skeleton must match the number of doses specified.")
+  }
+
   # lists
 
 model <- list()

--- a/app/modules/trial_design/global.R
+++ b/app/modules/trial_design/global.R
@@ -4,7 +4,6 @@ library(ggplot2)
 library(here)
 library(magrittr)
 library(escalation)
-library(rhandsontable)
 
 #DUMMY DATA MANIPULATION
 here::i_am("app/modules/trial_design/ui.R")

--- a/app/modules/trial_design/global.R
+++ b/app/modules/trial_design/global.R
@@ -2,6 +2,8 @@ library(shiny)
 library(DT)
 library(ggplot2)
 library(here)
+library(magrittr)
+library(escalation)
 
 #DUMMY DATA MANIPULATION
 here::i_am("app/modules/trial_design/ui.R")
@@ -148,9 +150,7 @@ mean_length$tpt <- mean(dist_length$tpt)
 #hist(dist_length$tpt,breaks=10)
 
 output <- list(
-    selection_df = selection_df$tpt, # % Times dose was selected as MTD
     selection_tab = selection_tab$tpt, # % Times dose was selected as MTD
-    treatedpct_df = treatedpct_df$tpt, # % Treated at each dose 
     treatment_tab = treatment_tab$tpt, # % Treated at each dose
     dist_accuracy = dist_accuracy$tpt, # Distribution of accuracy
     mean_accuracy = mean_accuracy$tpt, # Mean accuracy

--- a/app/modules/trial_design/global.R
+++ b/app/modules/trial_design/global.R
@@ -3,7 +3,6 @@ library(DT)
 library(ggplot2)
 library(here)
 
-
 #DUMMY DATA MANIPULATION
 here::i_am("app/modules/trial_design/ui.R")
 data_directory_dummy <- here('app','data','dummy') #define relative path to your questionnaire app directory
@@ -43,4 +42,4 @@ parse_params <- function(params_str) {
 
 questions <- dummy_data
 
-column_names <- sprintf("d(%d)", 1:n_doses)
+#column_names <- reactive({sprintf("d(%d)", 1:input$n_doses_inputt)})

--- a/app/modules/trial_design/global.R
+++ b/app/modules/trial_design/global.R
@@ -148,18 +148,16 @@ mean_length$tpt <- mean(dist_length$tpt)
 #hist(dist_length$tpt,breaks=10)
 
 output <- list(
-    sims = sims,
-    selection_df = selection_df$tpt,
-    selection_tab = selection_tab$tpt,
-    treatedpct = treatedpct$tpt,
-    treatedpct_df = treatedpct_df$tpt,
-    treatment_tab = treatment_tab$tpt,
-    dist_accuracy = dist_accuracy$tpt,
-    mean_accuracy = mean_accuracy$tpt,
-    dist_overdose = dist_overdose$tpt,
-    mean_overdose = mean_overdose$tpt,
-    dist_length = dist_length$tpt,
-    mean_length = mean_length$tpt
+    selection_df = selection_df$tpt, # % Times dose was selected as MTD
+    selection_tab = selection_tab$tpt, # % Times dose was selected as MTD
+    treatedpct_df = treatedpct_df$tpt, # % Treated at each dose 
+    treatment_tab = treatment_tab$tpt, # % Treated at each dose
+    dist_accuracy = dist_accuracy$tpt, # Distribution of accuracy
+    mean_accuracy = mean_accuracy$tpt, # Mean accuracy
+    dist_overdose = dist_overdose$tpt, # Distribution of overdose
+    mean_overdose = mean_overdose$tpt, # Mean overdose
+    dist_length = dist_length$tpt, # Distribution of trial length
+    mean_length = mean_length$tpt # Mean trial length
   )
   
   return(output)

--- a/app/modules/trial_design/global.R
+++ b/app/modules/trial_design/global.R
@@ -4,6 +4,7 @@ library(ggplot2)
 library(here)
 library(magrittr)
 library(escalation)
+library(rhandsontable)
 
 #DUMMY DATA MANIPULATION
 here::i_am("app/modules/trial_design/ui.R")
@@ -163,4 +164,159 @@ output <- list(
   return(output)
 }
 
+sim_crm <- function(n_doses, ttl, max_n, start_dose, n_sims, true_dlt_ss, skeleton, prior_var,
+                    skip_esc, skip_deesc, stop_tox_x, stop_tox_y, stop_n_mtd) {
+
+  
+  # lists
+
+model <- list()
+sims <- list()
+
+selection <- list()
+selection_df <- list()
+selection_tab <- list()
+
+treated <- list()
+treatedpct <- list()
+treatedpct_df <- list()
+treatment_tab <- list()
+
+dist_accuracy <- list()
+mean_accuracy <- list()
+
+dist_overdose <- list()
+mean_overdose <- list()
+
+dist_length <- list()
+mean_length <- list()
+
+# variables needed (UI)
+
+#n_doses <- 5
+#ttl <- 0.55
+#max_n <- 86
+#start_dose <- 3
+#current_seed <- 12345
+#true_dlt_ss <- c(0.05,0.15,1/3,0.5,0.8) # not dummy
+
+best_dose <- max(true_dlt_ss[true_dlt_ss<=ttl])
+best_dose_level <- match(best_dose,true_dlt_ss)
+
+# model crm
+
+#n_sims$crm <- 200
+
+#skeleton <- c(0.108321683015674,0.255548628279939,0.425089891767129,0.576775912195444,0.817103320499882)
+#prior_var <- 0.01
+
+#skip_esc <- FALSE
+#skip_deesc <- FALSE
+#stop_tox_x <- 0.11 
+#stop_tox_y <- 0.06
+#stop_n_mtd <- 45
+
+model$crm <- escalation::get_dfcrm(skeleton = skeleton, target = ttl, scale = sqrt(prior_var)) %>% 
+  dont_skip_doses(when_escalating = 1-skip_esc, when_deescalating = 1-skip_deesc) %>% 
+  stop_when_too_toxic(dose = 1, stop_tox_x + ttl, confidence = stop_tox_y) %>%
+  stop_when_n_at_dose(n = stop_n_mtd, dose = "recommended") %>%
+  stop_at_n(n=max_n) 
+
+########################################################################################################################################################
+
+
+## crm sims
+
+# run sims  
+
+sims$crm <- model$crm %>% 
+  escalation::simulate_trials(next_dose = start_dose, n_sims, true_dlt_ss, NULL)
+
+# find selection probs  
+
+selection$crm <- sims$crm %>% 
+  escalation::prob_recommend()
+
+# find no. treated at dose
+
+treated$crm <- colSums(sims$crm %>% 
+  escalation::n_at_dose())
+
+treatedpct$crm <- treated$crm / sum(treated$crm)
+
+# coerce into table
+
+selection_df$crm <- data.frame(selection$crm)
+treatedpct_df$crm <- data.frame(treatedpct$crm)
+selection_tab$crm <- rbind(t(selection_df$crm), c(NA,true_dlt_ss))
+
+rownames(selection_tab$crm) <- c("Dose Selected by Model", "True Toxicity Probabilities")
+
+# coerce into treatment table
+
+treatedpct_df$crm <- data.frame(treatedpct$crm)
+
+treatment_tab$crm <- rbind(t(treatedpct_df$crm),true_dlt_ss)
+
+rownames(treatment_tab$crm) <- c("Patients Treated by Model", "True Toxicity Probabilities")
+
+# i) accuracy
+
+dist_accuracy$crm <- recommended_dose(sims$crm)
+mean_accuracy$crm <- length(subset(dist_accuracy$crm,dist_accuracy$crm == best_dose_level)) / n_sims
+#hist(dist_accuracy$crm,breaks=10)
+
+# ii) risk of overdosing
+
+dist_overdose$crm <- num_tox(sims$crm)
+mean_overdose$crm <- mean(dist_overdose$crm)
+#hist(dist_overdose$crm,breaks=10)
+
+# iii) trial length
+
+dist_length$crm <- sims$crm %>% escalation::trial_duration()
+mean_length$crm <- mean(dist_length$crm)
+#hist(dist_length$crm,breaks=10)
+
+################################################################################################################################################################
+
+# current outputs:
+output <- list(
+    selection_tab = selection_tab$crm, # % Times dose was selected as MTD
+    treatment_tab = treatment_tab$crm, # % Treated at each dose
+    dist_accuracy = dist_accuracy$crm, # Distribution of accuracy
+    mean_accuracy = mean_accuracy$crm, # Mean accuracy
+    dist_overdose = dist_overdose$crm, # Distribution of overdose
+    mean_overdose = mean_overdose$crm, # Mean overdose
+    dist_length = dist_length$crm, # Distribution of trial length
+    mean_length = mean_length$crm # Mean trial length
+  )
+  
+  return(output)
+
+### PLOTS - To return to later.
+#par(mfrow = c(1,3))
+#graph_accuracy <- hist(dist_accuracy$tpt,breaks=11) %>% abline(v=mean_accuracy$tpt, col = "red")
+#graph_overdose <- hist(dist_overdose$tpt,breaks=11) %>% abline(v=mean_overdose$tpt, col = "red")
+#graph_length <- hist(dist_length$tpt,breaks=11) %>% abline(v=mean_length$tpt, col = "red")
+
+# df for graphs:
+
+#a <- cbind("tpt",dist_accuracy$tpt)
+#b <- cbind("crm",dist_accuracy$crm)
+
+#c <- data.frame(rbind(a,b))
+
+#ggplot2::ggplot(data = c, aes(x=X2, y=X1)) + 
+#geom_bar(stat = 'identity') +
+#scale_fill_manual(values=c("#69b3a2", "#404080")) 
+
+## trial conduct WIP
+
+# assuming we get the following:
+# id
+# dose level
+# cohort size
+# number in the cohort that had DLT
+}
 

--- a/app/modules/trial_design/server.R
+++ b/app/modules/trial_design/server.R
@@ -127,6 +127,19 @@ server_all <- function(input, output, session) {
     )
   })
 
+ # Simulation outputs
+
+  tpt_sim <- sim_tpt(n_doses = 5, ttl = 1/3, max_n = 30, start_dose = 1, n_sims = 100, true_dlt_ss = c(0.05,0.15,1/3,0.5,0.8), current_seed = 12345)
+  # Using the hardcoded values for now to make sure the table displays correctly. In the next commit, these values will be replaced with the desired ones.
+  tpt_sim_table <- tpt_sim$treatment_tab
+
+  output$scen_sim_output <-renderDT(tpt_sim_table, 
+    options = list(
+      pageLength = 5,
+      autoWidth = TRUE,
+      columnDefs = list(list(className = 'dt-center', targets = "_all"))
+    )
+  )
 
   ######################################## Conduct tab table code ########################################
 

--- a/app/modules/trial_design/server.R
+++ b/app/modules/trial_design/server.R
@@ -74,7 +74,7 @@ server_all <- function(input, output, session) {
   stop_tox_y_crm <- reactive({as.numeric(input$stop_tox_y_input)})  
 
   # 3+3
-  skip_tpt <- reactive({input$skip_tpt_input}) # This isn't used in the sim_tpt function
+  skip_tpt <- reactive({as.logical(input$skip_tpt_input)}) 
 
   ## Writing code such that the start dose cannot be greater than the number of doses and the number of doses cannot be less than the start dose
 
@@ -195,8 +195,8 @@ server_all <- function(input, output, session) {
 
   # Design - only running simulations that are necessary to save time.
   if ("3+3" %in% input$simulation_design_selection_input)
-      { print(unlist(used_true_dlts[j, ]))
-        tpt_sim <- sim_tpt(n_dosess(), ttl(), max_size(), start_dose(), n_sims(), unlist(used_true_dlts[j, ]), 12345)
+      { #print(unlist(used_true_dlts[j, ]))
+        tpt_sim <- sim_tpt(n_dosess(), ttl(), max_size(), start_dose(), n_sims(), unlist(used_true_dlts[j, ]), skip_tpt(), 12345)
        tpt_modified_tab <- tpt_sim[-c(3,5,7)]
       } else {tpt_modified_tab <- NULL}
   if ("CRM" %in% input$simulation_design_selection_input)

--- a/app/modules/trial_design/server.R
+++ b/app/modules/trial_design/server.R
@@ -58,6 +58,19 @@ server_all <- function(input, output, session) {
   n_sims <- reactive({as.numeric(input$n_sims_input)})
   n_scenarios <- reactive({as.numeric(input$n_scenarios_input)})
 
+  ## Writing code such that the start dose cannot be greater than the number of doses and the number of doses cannot be less than the start dose
+
+  # start_dose cannot be greater than the n_doses
+   observe({
+    updateNumericInput(session, "start_dose_inputt", max = input$n_doses_inputt)
+  })
+  
+  # n_doses cannot be less than the start_dose
+  observe({
+    # Update the min value of the maxValue input based on minValue
+    updateNumericInput(session, "n_doses_inputt", min = input$start_dose_inputt)
+  })
+
   ######################################## Configuration tab's simulation scenarios table code ########################################
 
   #Initialize empty data frame with specified columns

--- a/app/modules/trial_design/server.R
+++ b/app/modules/trial_design/server.R
@@ -186,8 +186,8 @@ server_all <- function(input, output, session) {
 
    # Metric - putting it outside of the for loop so only one list is created.
   selected_metric <- cbind(
-  selected_participant <- {"% participants treated at dose" %in% input$metric_selection_input},
   selected_mtd <- {"% times dose was selected as MTD" %in% input$metric_selection_input},
+  selected_participant <- {"% participants treated at dose" %in% input$metric_selection_input},
   selected_accuracy <- {"Accuracy" %in% input$metric_selection_input},
   selected_duration <- {"Duration" %in% input$metric_selection_input},
   selected_overdose <- {"Overdosing" %in% input$metric_selection_input})
@@ -212,7 +212,7 @@ server_all <- function(input, output, session) {
   tpt_title <- as.character(rep("3+3 Simulation for Scenario ", 5))
   crm_title <- as.character(rep("CRM Simulation for Scenario ", 5))
   scenario_number <- as.character(rep(j, 5))
-  metric_names <- as.character(c("- % Treated at each dose", " - % Times dose was selected as MTD",  " - Mean accuracy", " - Mean trial length", " - Mean overdose"))
+  metric_names <- as.character(c(" - % Times dose was selected as MTD", "- % Treated at each dose",  " - Mean accuracy", " - Mean trial length", " - Mean overdose"))
 
   if ("3+3" %in% input$simulation_design_selection_input) {
   full_tpt_titles <- paste(as.character(tpt_title), as.character(scenario_number), as.character(metric_names))
@@ -232,7 +232,7 @@ server_all <- function(input, output, session) {
 
   tpt_data_frames <- lapply(tpt_to_display, function(x) as.data.frame(x)) # Converting the list into a list of dataframes
   crm_data_frames <- lapply(crm_to_display, function(x) as.data.frame(x)) # Converting the list into a list of dataframes
-
+ 
   combined_list[[j]]  <- cbind(tpt_data_frames, crm_data_frames)
   cbind_titles <- cbind(used_tpt_titles, used_crm_titles)
   title_list[[j]] <- unname(unlist(cbind_titles))
@@ -241,7 +241,7 @@ server_all <- function(input, output, session) {
 
   combined_data_frames <- do.call(c, combined_list) 
   combined_titles <- do.call(c, title_list) 
- print(combined_titles)
+  
   n_data_frames <- length(combined_data_frames)
 
   # Using generic table names to render the UI with all the tables in it.
@@ -265,7 +265,7 @@ server_all <- function(input, output, session) {
   lapply(names(combined_data_frames), function(table_name) {
     output[[paste0("table_", table_name)]] <- renderTable({
       combined_data_frames[[table_name]]
-    }) 
+    }, rownames = TRUE, colnames = TRUE) 
   }) 
 
   

--- a/app/modules/trial_design/server.R
+++ b/app/modules/trial_design/server.R
@@ -133,13 +133,16 @@ server_all <- function(input, output, session) {
   # Using the hardcoded values for now to make sure the table displays correctly. In the next commit, these values will be replaced with the desired ones.
   tpt_sim_table <- tpt_sim$treatment_tab
 
-  output$scen_sim_output <-renderDT(tpt_sim_table, 
+observeEvent(input$submit, {
+    output$scen_sim_output <- renderDT(tpt_sim_table, 
     options = list(
       pageLength = 5,
       autoWidth = TRUE,
       columnDefs = list(list(className = 'dt-center', targets = "_all"))
     )
   )
+  })
+
 
   ######################################## Conduct tab table code ########################################
 

--- a/app/modules/trial_design/server.R
+++ b/app/modules/trial_design/server.R
@@ -99,45 +99,40 @@ server_all <- function(input, output, session) {
     #Update reactive data frame
     reactive_table_data(updated_data)
   })
-  
-  output$editable_table <- renderDT({
-    datatable(reactive_table_data(), editable = TRUE, options = list(columnDefs = list(list(className = 'dt-center', targets = "_all"), list(targets = 0, className = "not-editable"))), rownames = FALSE)
-      #scrollX = TRUE, scrollX="250px", paging = FALSE
-    #options = list(scrollX = TRUE, scrollX="250px", paging = FALSE) #Did not work
-  }, server = FALSE)
-  
+
+
   output$table_output <- renderDT({
     datatable(reactive_table_data(), editable = TRUE, options = list(columnDefs = list(list(className = 'dt-center', targets = "_all"))), rownames = FALSE)
       #scrollX = TRUE, scrollX="250px", paging = FALSE
     #options = list(scrollX = TRUE, scrollX="250px", paging = FALSE) #Did not work
   })
   
-  observeEvent(input$table_output_cell_edit, {
-    info <- input$table_output_cell_edit
-    modified_data <- reactive_table_data()
-    modified_data[info$row, (info$col + 1)] <- as.numeric(info$value)
-    reactive_table_data(modified_data)
-  })
+  #observeEvent(input$table_output_cell_edit, {
+    #info <- input$table_output_cell_edit
+   # modified_data <- reactive_table_data()
+   # modified_data[info$row, (info$col + 1)] <- as.numeric(info$value)
+   # reactive_table_data(modified_data)
+ # })
   
-  observeEvent(input$plot_button, {
+ # observeEvent(input$plot_button, {
     #Capture current data and transform for plotting
-    current_data <- reactive_table_data()
-    plot_data <- tidyr::gather(current_data[, -1, drop = FALSE], key = "Dose Level", value = "Value")
-    plot_data$Scenario <- rep(current_data$Scenario, each = ncol(current_data) - 1)
+  #  current_data <- reactive_table_data()
+  #  plot_data <- tidyr::gather(current_data[, -1, drop = FALSE], key = "Dose Level", value = "Value")
+   # plot_data$Scenario <- rep(current_data$Scenario, each = ncol(current_data) - 1)
     
     #Create the plot
-    p <- ggplot(plot_data, aes(x = `Dose Level`, y = Value)) +
-      geom_line() +
-      geom_point() +
-      labs(x = "Dose Levels",
-           y = "'True' DLT Rates") +
-      theme_minimal()
+   # p <- ggplot(plot_data, aes(x = `Dose Level`, y = Value)) +
+    #  geom_line() +
+   #   geom_point() +
+    #  labs(x = "Dose Levels",
+    #       y = "'True' DLT Rates") +
+    #  theme_minimal()
     
     # Render the plot
-    output$plot <- renderPlot({
-      p
-    })
-  })
+    #output$plot <- renderPlot({
+   #   p
+   # })
+ # })
   
 
   ######################################## Simulation tab server code ########################################

--- a/app/modules/trial_design/server.R
+++ b/app/modules/trial_design/server.R
@@ -138,11 +138,10 @@ server_all <- function(input, output, session) {
        tpt_modified_tab <- tpt_sim[-c(3,5,7)]
       }
     else {tpt_modified_tab <- NULL}
-  if ("crm" %in% input$simulation_design_selection_input)
-    #  {crm_sim <- sim_crm(5, 0.55, 86, 3, 10, c(0.05, 0.15, 1/3, 0.5, 0.8), 12345)
-    #   crm_modified_tab <- tpt_sim[-c(3,5,7)]
-    #  } 
-    {crm_sim <- NULL} # FOR NOW. This will be deleted in future commits.
+  if ("CRM" %in% input$simulation_design_selection_input)
+      {crm_sim <- sim_crm(3, 0.3, 10, 1, 10, c(0.1, 0.3, 0.6), c(0.11, 0.22, 0.56), 0.1, FALSE, FALSE, 0.11, 0.06, 45)
+       crm_modified_tab <- crm_sim[-c(3,5,7)]
+      } 
   else {crm_modified_tab <- NULL}
 
   # Metric

--- a/app/modules/trial_design/server.R
+++ b/app/modules/trial_design/server.R
@@ -61,9 +61,9 @@ server_all <- function(input, output, session) {
 
   # Model-specific variables from configuration tab
   # CRM
-  skip_esc_crm <- reactive({input$skip_esc_crm_input})
-  skip_deesc_crm <- reactive({input$skip_deesc_crm_input})
-  above_target_crm <- reactive({input$above_target_input}) # This isn't used in the sim_crm function
+  skip_esc_crm <- reactive({as.logical(input$skip_esc_crm_input)})
+  skip_deesc_crm <- reactive({as.logical(input$skip_deesc_crm_input)})
+  above_target_crm <- reactive({as.logical(input$above_target_input)}) # This isn't used in the sim_crm function
   prior_var_crm <- reactive({as.numeric(input$prior_var_input)})
   stop_n_mtd_crm <- reactive({as.numeric(input$stop_n_mtd_input)})
   skeleton_crm <- reactive({
@@ -200,7 +200,8 @@ server_all <- function(input, output, session) {
        tpt_modified_tab <- tpt_sim[-c(3,5,7)]
       } else {tpt_modified_tab <- NULL}
   if ("CRM" %in% input$simulation_design_selection_input)
-      {crm_sim <- sim_crm(3, 0.3, 10, 1, 10, c(0,1,0.2,0.3), c(0.11, 0.22, 0.56), 0.1, FALSE, FALSE, 0.11, 0.06, 45)
+      {
+        crm_sim <- sim_crm(n_dosess(), ttl(), max_size(), start_dose(), n_sims(), unlist(used_true_dlts[j, ]), skeleton_crm(), prior_var_crm(), skip_esc_crm(), skip_deesc_crm(), stop_tox_x_crm(), stop_tox_y_crm(), stop_n_mtd_crm())
        crm_modified_tab <- crm_sim[-c(3,5,7)]
       } else {crm_modified_tab <- NULL}
 

--- a/app/modules/trial_design/server.R
+++ b/app/modules/trial_design/server.R
@@ -92,8 +92,7 @@ server_all <- function(input, output, session) {
   ######################################## Configuration tab's simulation scenarios table code ########################################
 
   
-  # Create a data frame with the specified number of rows and columns
-  ## NOTE: The first column rounds all entries to the nearest integer - this will be fixed in a future commit.
+  # Creating a data frame with the specified number of rows and columns
 
   reactive_df <- reactiveVal() # initalising a reactive value to store the data frame
 
@@ -103,7 +102,7 @@ server_all <- function(input, output, session) {
   colnames(dimensions) <- paste("d", 1:input$n_doses_inputt, sep = "")
   dataframe <- data.frame(dimensions) # What was previously doses_table
 
-  Scenario <- matrix(1:input$n_scenarios_input, nrow = input$n_scenarios_input, ncol = 1)
+  Scenario <- matrix(as.numeric(1:input$n_scenarios_input), nrow = input$n_scenarios_input, ncol = 1)
   
   dataframe_row_1 <- data.frame(Scenario) # What was previously scenarios_table
 
@@ -122,6 +121,7 @@ server_all <- function(input, output, session) {
     modified_data <- reactive_df()
     modified_data[info$row, info$col + 1] <- DT::coerceValue(info$value, modified_data[info$row, info$col]) # +1 is here to counterract the movement of edited data.
     reactive_df(modified_data)
+    #print(str(reactive_df()))
   })
 
   true_dlts <- reactive({
@@ -129,9 +129,9 @@ server_all <- function(input, output, session) {
   })
   
 
-  output$table_output <- DT::renderDT({
-    datatable(true_dlts(), editable = TRUE, rownames = FALSE, options = list(scrollX = TRUE, scrollY = "250px", paging = FALSE))
-  })
+  #output$table_output <- DT::renderDT({
+  #  datatable(true_dlts(), editable = TRUE, rownames = FALSE, options = list(scrollX = TRUE, scrollY = "250px", paging = FALSE))
+  #})
   
  # observeEvent(input$plot_button, {
     #Capture current data and transform for plotting

--- a/app/modules/trial_design/server.R
+++ b/app/modules/trial_design/server.R
@@ -49,7 +49,8 @@ server_all <- function(input, output, session) {
   )
 
   ################################ Configuration tab's sidebar code ################################
-   
+
+  # General variables from configuration tab 
   n_dosess <- reactive({as.numeric(input$n_doses_inputt)}) # Using double ending letters to avoid mixing up with other input (for now)
   ttl <- reactive({as.numeric(input$ttl_inputt)})
   max_size <- reactive({as.numeric(input$max_size_inputt)})
@@ -57,6 +58,23 @@ server_all <- function(input, output, session) {
   cohort_size <- reactive({as.numeric(input$cohort_inputt)})
   n_sims <- reactive({as.numeric(input$n_sims_input)})
   n_scenarios <- reactive({as.numeric(input$n_scenarios_input)})
+
+  # Model-specific variables from configuration tab
+  # CRM
+  skip_esc_crm <- reactive({input$skip_esc_crm_input})
+  skip_deesc_crm <- reactive({input$skip_deesc_crm_input})
+  above_target_crm <- reactive({input$above_target_input}) # This isn't used in the sim_crm function
+  prior_var_crm <- reactive({as.numeric(input$prior_var_input)})
+  stop_n_mtd_crm <- reactive({as.numeric(input$stop_n_mtd_input)})
+  skeleton_crm <- reactive({
+    as.numeric(unlist(strsplit(input$skeleton_input, ",")))
+  })
+  prior_mtd_crm <- reactive({as.numeric(input$prior_mtd_input)})  # This isn't used in the sim_crm function
+  stop_tox_x_crm <- reactive({as.numeric(input$stop_tox_x_input)})
+  stop_tox_y_crm <- reactive({as.numeric(input$stop_tox_y_input)})  
+
+  # 3+3
+  skip_tpt <- reactive({input$skip_tpt_input}) # This isn't used in the sim_tpt function
 
   ## Writing code such that the start dose cannot be greater than the number of doses and the number of doses cannot be less than the start dose
 
@@ -75,6 +93,7 @@ server_all <- function(input, output, session) {
 
   
   # Create a data frame with the specified number of rows and columns
+  ## NOTE: The first column rounds all entries to the nearest integer - this will be fixed in a future commit.
 
   reactive_df <- reactiveVal() # initalising a reactive value to store the data frame
 

--- a/app/modules/trial_design/server.R
+++ b/app/modules/trial_design/server.R
@@ -73,46 +73,27 @@ server_all <- function(input, output, session) {
 
   ######################################## Configuration tab's simulation scenarios table code ########################################
 
-  #Initialize empty data frame with specified columns
-  reactive_table_data <- reactiveVal(data.frame(matrix(ncol = n_doses, nrow = 0, dimnames = list(NULL, column_names))))
   
-  observe({
-    #Capture current data
-    current_data <- reactive_table_data()
+  # Create a data frame with the specified number of rows and columns
+
+  doses_table <- reactive({
+    dimensions <- matrix(0, nrow = input$n_scenarios_input, ncol = input$n_doses_inputt)
+    dataframe <- data.frame(dimensions)
     
-    #Calculate rows to add or remove
-    target_rows <- as.numeric(input$n_scenarios_input)
-    current_rows <- nrow(current_data)
-    rows_to_add <- target_rows - current_rows
-    
-    #Update data based on the difference
-    if (rows_to_add > 0) {
-      new_rows <- data.frame(
-        Scenario = seq_len(rows_to_add) + current_rows,
-        matrix(0, ncol = n_doses, nrow = rows_to_add, dimnames = list(NULL, column_names))
-        )
-      updated_data <- rbind(current_data, new_rows)
-    } else {
-      updated_data <- head(current_data, target_rows)
-    }
-    
-    #Update reactive data frame
-    reactive_table_data(updated_data)
   })
 
-
-  output$table_output <- renderDT({
-    datatable(reactive_table_data(), editable = TRUE, options = list(columnDefs = list(list(className = 'dt-center', targets = "_all"))), rownames = FALSE)
-      #scrollX = TRUE, scrollX="250px", paging = FALSE
-    #options = list(scrollX = TRUE, scrollX="250px", paging = FALSE) #Did not work
+  scenario_table <- reactive({
+    Scenario <- matrix(1:input$n_scenarios_input, nrow = input$n_scenarios_input, ncol = 1)
+    dataframe_row_1 <- data.frame(Scenario)
   })
-  
-  #observeEvent(input$table_output_cell_edit, {
-    #info <- input$table_output_cell_edit
-   # modified_data <- reactive_table_data()
-   # modified_data[info$row, (info$col + 1)] <- as.numeric(info$value)
-   # reactive_table_data(modified_data)
- # })
+
+  reactive_df <- reactive({cbind(scenario_table(), doses_table())})
+
+
+  output$test_df <- renderDT({
+    datatable(reactive_df(), editable = list(target = "cell", columns = c(2:(input$n_doses_inputt + 1))), options = list(columnDefs = list(list(className = 'dt-center', targets = "_all"))), rownames = FALSE, colnames = c("Scenario", paste(rep("d", input$n_doses_inputt), as.list(as.character(1:input$n_doses_inputt)), sep = ""))) #, scrollX = TRUE, scrollX="250px", paging = FALSE
+  })
+
   
  # observeEvent(input$plot_button, {
     #Capture current data and transform for plotting
@@ -134,7 +115,6 @@ server_all <- function(input, output, session) {
    # })
  # })
   
-
   ######################################## Simulation tab server code ########################################
 
   new_n_scen <- reactive(as.numeric(input$n_scenarios_input))

--- a/app/modules/trial_design/server.R
+++ b/app/modules/trial_design/server.R
@@ -48,7 +48,15 @@ server_all <- function(input, output, session) {
     }
   )
 
-
+  ################################ Configuration tab's sidebar code ################################
+   
+  n_dosess <- reactive({as.numeric(input$n_doses_inputt)}) # Using double ending letters to avoid mixing up with other input (for now)
+  ttl <- reactive({as.numeric(input$ttl_inputt)})
+  max_size <- reactive({as.numeric(input$max_size_inputt)})
+  start_dose <- reactive({as.numeric(input$start_dose_inputt)}) 
+  cohort_size <- reactive({as.numeric(input$cohort_inputt)})
+  n_sims <- reactive({as.numeric(input$n_sims_input)})
+  n_scenarios <- reactive({as.numeric(input$n_scenarios_input)})
 
   ######################################## Configuration tab's simulation scenarios table code ########################################
 

--- a/app/modules/trial_design/ui.R
+++ b/app/modules/trial_design/ui.R
@@ -147,9 +147,9 @@ sim_tab_input_func <- function() {
 
      ),
 
-     mainPanel("INSERT DYNAMIC SIMULATION OUTPUTS HERE"
-
-    ) )
+     mainPanel( width = 7,
+      DT::DTOutput("scen_sim_output") # Ouputting the simulation results - for now, this is just the tpt table.
+     )) 
  }
 
 #CONDUCT TAB

--- a/app/modules/trial_design/ui.R
+++ b/app/modules/trial_design/ui.R
@@ -78,12 +78,13 @@ non_specific_column_func <- function() {
   n_sims_input <- numericInput("n_sims_input", "How many simulations would you like to run per design per scenario?", value = 10)
   n_scenarios_input <- numericInput("n_scenarios_input", "How many scenarios would you like to simulate?", min = 1, max = 3, value = 3) # Capping the number of scenarios at 3 (for now)
   text2 <- "Please fill out each scenario's and each dose's 'True' Dose Limiting Toxicity probabilities in the table below:"
-  table_output <- DT::DTOutput("table_output")
+  table_output <- DT::DTOutput("table_output") # This is to test the table output used for the simulations tab.
   test_df_table <- DT::DTOutput("test_df")
   #plot_button <- actionButton("plot_button", label = "Test plot")
   #plot <- plotOutput("plot")
   return <- list(upload_button, download_button, separator, title, display_button, conditional_non_specific_ui_inputs,
-  separator, text, n_sims_input, n_scenarios_input, text2, table_output, test_df_table)
+  separator, text, n_sims_input, n_scenarios_input, text2, #table_output, 
+  test_df_table)
 }
 
 ##Defining Configurations tab columns

--- a/app/modules/trial_design/ui.R
+++ b/app/modules/trial_design/ui.R
@@ -76,7 +76,7 @@ non_specific_column_func <- function() {
   separator <- "___________________________________________"
   text <- "SIMULATION PARAMETERS"
   n_sims_input <- numericInput("n_sims_input", "How many simulations would you like to run per design per scenario?", value = 10)
-  n_scenarios_input <- numericInput("n_scenarios_input", "How many scenarios would you like to simulate?", min = 1, value = 3)
+  n_scenarios_input <- numericInput("n_scenarios_input", "How many scenarios would you like to simulate?", min = 1, max = 3, value = 3) # Capping the number of scenarios at 3 (for now)
   text2 <- "Please fill out each scenario's and each dose's 'True' Dose Limiting Toxicity probabilities in the table below:"
   table_output <- DT::DTOutput("table_output")
   test_df_table <- DT::DTOutput("test_df")

--- a/app/modules/trial_design/ui.R
+++ b/app/modules/trial_design/ui.R
@@ -46,12 +46,26 @@ specific_ui_inputs <- lapply(ranking, function(method_current) {
   )
 })
 
-
+# Trying a different method
 
 #CONFIGURATIONS TAB
 
 ##Defining non-design-specific + simulation parameters column inputs function
 non_specific_column_func <- function() {
+  n_doses_output <- numericInput("n_doses_inputt", "How many dose levels are being tested?", min = 1, value = "3")
+  ttl_output <- numericInput("ttl_inputt", "What is the target toxicity level for this trial, as a decimal?", min = 0, max = 1, value = "0.3")
+  max_size_output <- numericInput("max_size_inputt", "What is the maximum sample size for this trial?", min = 1, value = "30")
+  start_dose_output <- numericInput("start_dose_inputt", "What is the starting dose level?", min = 1, value = "1")
+  cohort_output <- numericInput("cohort_inputt", "What size will the cohorts be?", min = 1, value = "5")
+  non_specific_ui_inputts <- tagList(
+    n_doses_output,
+    ttl_output,
+    max_size_output,
+    start_dose_output,
+    cohort_output
+  )
+
+
   #label <- "Input file with all configurations"
   upload_button <- fileInput("config_file_upload", "Input file with all configurations", accept = c(".csv", ".rds"))
   #label_2 <- "Download file with all configurations"
@@ -59,7 +73,7 @@ non_specific_column_func <- function() {
   separator <- "___________________________________________"
   title <- "GENERAL TRIAL PARAMETERS"
   display_button <- checkboxInput("display_input_all", "Display parameters", value = F)
-  conditional_non_specific_ui_inputs <- conditionalPanel(condition = "input.display_input_all==1", non_specific_ui_inputs)
+  conditional_non_specific_ui_inputs <- conditionalPanel(condition = "input.display_input_all==1", non_specific_ui_inputts)
   separator <- "___________________________________________"
   text <- "SIMULATION PARAMETERS"
   n_sims_input <- numericInput("n_sims_input", "How many simulations would you like to run per design per scenario?", value = 10)
@@ -68,7 +82,9 @@ non_specific_column_func <- function() {
   table_output <- DT::DTOutput("table_output")
   #plot_button <- actionButton("plot_button", label = "Test plot")
   #plot <- plotOutput("plot")
-  return <- list(upload_button, download_button, separator, title, display_button, conditional_non_specific_ui_inputs, separator, text, n_sims_input, n_scenarios_input, text2, table_output)
+  return <- list(upload_button, download_button, separator, title, display_button, conditional_non_specific_ui_inputs,
+  #n_doses_output, ttl_output, max_size_output, start_dose_output, cohort_output, 
+  separator, text, n_sims_input, n_scenarios_input, text2, table_output)
 }
 
 ##Defining Configurations tab columns
@@ -132,9 +148,9 @@ sim_tab_input_func <- function() {
 
      ),
 
-     mainPanel("INSERT DYNAMIC SIMULATION OUTPUTS HERE")
+     mainPanel("INSERT DYNAMIC SIMULATION OUTPUTS HERE"
 
-    )
+    ) )
  }
 
 
@@ -180,6 +196,7 @@ ui_tabs[[3]] <- tabPanel("Conduct",
 ui <- fluidPage(
   do.call(tabsetPanel, c(ui_tabs))
 )
+
 
 
 

--- a/app/modules/trial_design/ui.R
+++ b/app/modules/trial_design/ui.R
@@ -52,7 +52,7 @@ specific_ui_inputs <- lapply(ranking, function(method_current) {
 
 ##Defining non-design-specific + simulation parameters column inputs function
 non_specific_column_func <- function() {
-  n_doses_output <- numericInput("n_doses_inputt", "How many dose levels are being tested?", min = 1, value = "3")
+  n_doses_output <- numericInput("n_doses_inputt", "How many dose levels are being tested?", min = 1, value = "5")
   ttl_output <- numericInput("ttl_inputt", "What is the target toxicity level for this trial, as a decimal?", min = 0, max = 1, value = "0.3")
   max_size_output <- numericInput("max_size_inputt", "What is the maximum sample size for this trial?", min = 1, value = "30")
   start_dose_output <- numericInput("start_dose_inputt", "What is the starting dose level?", min = 1, value = "1")
@@ -106,12 +106,12 @@ select_specific_columns <- function() {
   # return(specific_columns)
 
 skip_esc_crm_input <- radioButtons("skip_esc_crm_input","Would you like to be able to skip doses when escalating?",
-choices = c("Yes", "No"), selected = "No", inline = TRUE)
+choices = c("Yes" = TRUE, "No" = FALSE), selected = FALSE, inline = TRUE)
 skip_deesc_crm_input <- radioButtons("skip_deesc_crm_input","Would you like to be able to skip doses when de-escalating?",
-choices = c("Yes", "No"), selected = "Yes", inline = TRUE)
+choices = c("Yes" = TRUE, "No" = FALSE), selected = TRUE, inline = TRUE)
 above_target_input <- radioButtons("above_target_input",
 "Do you want to prevent escalation of doses if the overall observed DLT rate at the current dose level is above the target DLT rate?",
-choices = c("Yes", "No"), selected = "Yes", inline = TRUE)
+choices = c("Yes" = TRUE, "No" = FALSE), selected = TRUE, inline = TRUE)
 prior_var_input <- numericInput("prior_var_input", "What is the estimate of the prior variance?", min = 0, value = 0.1)
 stop_n_mtd_input <- numericInput("stop_n_mtd_input", "What is the minimum number of patients required at recommended dose before early stopping?", min = 1, value = 24)
 skeleton_input <- textInput("skeleton_input", "What are the prior estimates of the DLT rates at each dose? Please make this an increasing list and separate each value with a comma.", value = "0.108321683015674,0.255548628279939,0.425089891767129,0.576775912195444,0.817103320499882")
@@ -131,10 +131,10 @@ specific_ui_inputs_crm <- tagList(
 )
 
 skip_tpt_input <- radioButtons("skip_tpt_input","Would you like to be able to skip doses when de-escalating?",
-choices = c("Yes", "No"), selected = "Yes", inline = TRUE)
+choices = c("Yes" = TRUE, "No" = FALSE), selected = TRUE, inline = TRUE)
 
 specific_ui_inputs_other <- radioButtons("specific_ui_inputs_other","This is a placeholder. Clicking this button will do nothing.",
-choices = c("Yes", "No"), selected = "Yes", inline = TRUE) 
+choices = c("Yes" = TRUE, "No" = FALSE), selected = TRUE, inline = TRUE)
 
 
 title1 <- "1: CRM"

--- a/app/modules/trial_design/ui.R
+++ b/app/modules/trial_design/ui.R
@@ -65,7 +65,6 @@ non_specific_column_func <- function() {
     cohort_output
   )
 
-
   #label <- "Input file with all configurations"
   upload_button <- fileInput("config_file_upload", "Input file with all configurations", accept = c(".csv", ".rds"))
   #label_2 <- "Download file with all configurations"
@@ -80,11 +79,11 @@ non_specific_column_func <- function() {
   n_scenarios_input <- numericInput("n_scenarios_input", "How many scenarios would you like to simulate?", min = 1, value = 3)
   text2 <- "Please fill out each scenario's and each dose's 'True' Dose Limiting Toxicity probabilities in the table below:"
   table_output <- DT::DTOutput("table_output")
+  test_df_table <- DT::DTOutput("test_df")
   #plot_button <- actionButton("plot_button", label = "Test plot")
   #plot <- plotOutput("plot")
   return <- list(upload_button, download_button, separator, title, display_button, conditional_non_specific_ui_inputs,
-  #n_doses_output, ttl_output, max_size_output, start_dose_output, cohort_output, 
-  separator, text, n_sims_input, n_scenarios_input, text2, table_output)
+  separator, text, n_sims_input, n_scenarios_input, text2, table_output, test_df_table)
 }
 
 ##Defining Configurations tab columns
@@ -152,8 +151,6 @@ sim_tab_input_func <- function() {
 
     ) )
  }
-
-
 
 #CONDUCT TAB
 

--- a/app/modules/trial_design/ui.R
+++ b/app/modules/trial_design/ui.R
@@ -147,11 +147,11 @@ sim_tab_input_func <- function() {
 
      ),
 
-     mainPanel( width = 7,
-      DT::DTOutput("scen_sim_output") # Ouputting the simulation results - for now, this is just the tpt table.
-     )) 
- }
-
+     mainPanel(width = 7, uiOutput("tables_ui") # Ouputting the simulation results - for now, this is just the tpt tables.
+     )
+  )}
+       # Ouputting the simulation results - for now, this is just the tpt table.
+ 
 #CONDUCT TAB
 
 ##Conduct tab UI function

--- a/app/modules/trial_design/ui.R
+++ b/app/modules/trial_design/ui.R
@@ -90,19 +90,72 @@ non_specific_column_func <- function() {
 display_input_id <- list()
 display_condition <- list()
 specific_columns <- list()
+
 select_specific_columns <- function() {
-  for(n in 1:(length(ranking))) {
-    display_input_id[[n]] <- paste0("display_input_", ranking[n], sep="")
-    display_condition[[n]] <- paste0("input.", display_input_id[[n]], "==1", sep="")
-    specific_columns[[n]] <- column(
-      n,
-      paste0(": ", pretty_ranking[n]),
-      checkboxInput(display_input_id[[n]], "Display parameters", value = F),
-      conditionalPanel(condition = display_condition[[n]], specific_ui_inputs[[n]]),
-      width = 4)
-  }
-  return(specific_columns)
+  
+  #for(n in 1:(length(ranking))) {
+   # display_input_id[[n]] <- paste0("display_input_", ranking[n], sep="")
+   # display_condition[[n]] <- paste0("input.", display_input_id[[n]], "==1", sep="")
+   # specific_columns[[n]] <- column(
+   #   n,
+    #  paste0(": ", pretty_ranking[n]),
+    #  checkboxInput(display_input_id[[n]], "Display parameters", value = F),
+    #  conditionalPanel(condition = display_condition[[n]], specific_ui_inputs[[n]]),
+    #  width = 4)
+  # }
+  # return(specific_columns)
+
+skip_esc_crm_input <- radioButtons("skip_esc_crm_input","Would you like to be able to skip doses when escalating?",
+choices = c("Yes", "No"), selected = "No", inline = TRUE)
+skip_deesc_crm_input <- radioButtons("skip_deesc_crm_input","Would you like to be able to skip doses when de-escalating?",
+choices = c("Yes", "No"), selected = "Yes", inline = TRUE)
+above_target_input <- radioButtons("above_target_input",
+"Do you want to prevent escalation of doses if the overall observed DLT rate at the current dose level is above the target DLT rate?",
+choices = c("Yes", "No"), selected = "Yes", inline = TRUE)
+prior_var_input <- numericInput("prior_var_input", "What is the estimate of the prior variance?", min = 0, value = 0.1)
+stop_n_mtd_input <- numericInput("stop_n_mtd_input", "What is the minimum number of patients required at recommended dose before early stopping?", min = 1, value = 24)
+skeleton_input <- textInput("skeleton_input", "What are the prior estimates of the DLT rates at each dose? Please make this an increasing list and separate each value with a comma.", value = "0.108321683015674,0.255548628279939,0.425089891767129,0.576775912195444,0.817103320499882")
+prior_mtd_input <- numericInput("prior_mtd_input", "What is your prior guess of the MTD?", min = 1, value = 8)
+stop_tox_x_input <- numericInput("stop_tox_x_input", "When using the this Bayesian safety early criterion: p(true DLT rate at lowest dose > target DLT rate + x | data) > y, what would you like x to be? This is the excess toxicity above the target DLT.", min = 0, value = 0.09)
+stop_tox_y_input <- numericInput("stop_tox_y_input", "What would you like y to be? This is the confidence level for safety stopping.", min = 0, max = 1, value = 0.77)
+specific_ui_inputs_crm <- tagList(
+  skip_esc_crm_input,
+  skip_deesc_crm_input,
+  above_target_input,
+  prior_var_input,
+  stop_n_mtd_input,
+  skeleton_input,
+  prior_mtd_input,
+  stop_tox_x_input,
+  stop_tox_y_input
+)
+
+skip_tpt_input <- radioButtons("skip_tpt_input","Would you like to be able to skip doses when de-escalating?",
+choices = c("Yes", "No"), selected = "Yes", inline = TRUE)
+
+specific_ui_inputs_other <- radioButtons("specific_ui_inputs_other","This is a placeholder. Clicking this button will do nothing.",
+choices = c("Yes", "No"), selected = "Yes", inline = TRUE) 
+
+
+title1 <- "1: CRM"
+display_button_crm <- checkboxInput("display_crm", "Display parameters", value = F)
+conditional_crm <- conditionalPanel(condition = "input.display_crm==1", specific_ui_inputs_crm, width = 4)
+
+title2 <- "2: 3+3"
+display_button_tpt <- checkboxInput("display_tpt", "Display parameters", value = F)
+conditional_tpt <- conditionalPanel(condition = "input.display_tpt==1", skip_tpt_input, width = 4)
+
+title3 <- "3: Other (TEST)"
+display_button_other <- checkboxInput("display_other", "Display parameters", value = F)
+conditional_other <- conditionalPanel(condition = "input.display_other==1", specific_ui_inputs_other, width = 4)
+
+fluidRow(column(4,title1, display_button_crm, conditional_crm),
+  column(4,title2, display_button_tpt, conditional_tpt),
+  column(4,title3, display_button_other, conditional_other)
+)
 }
+
+
 
 ##Defining Configurations tab input function
 config_tab_input_func <- function() {


### PR DESCRIPTION
## Summary

This PR is a finished first draft of the Configurations and Simulations tabs of the Main UI, to be transferred over to the Trial Designs and Simulations tabs of the restructured app after this PR is reviewed and approved. This builds on some of the aims of issue #33.

## The Functions of this First Draft

### The Configurations Tab
- The Configurations tab should look the similar to before, but with the sliders replaced with numeric inputs and a working reactive table at the bottom of the sidebar, which is editable and changes dimension when the number of scenarios and/or doses are changed.
- The number of doses entered cannot be less than the starting dose, and vice versa.
- All entries to the Configurations tab should now be reactive and their values are tracked (this was not the case previously).

### The Simulations Tab
- The CRM and 3+3 simulations from `basesim.R` have been copied over and rewritten as functions in `global.R`. `basesim.R` has been left unchanged.
- The Simulations tab should look the same as before, but now, when Submit is clicked, the corresponding simulations to the selected options should be displayed below each other to the right of the sidebar, as below. The presentation of the data isn't the best, but I have left it this way to fix when in the reconstructed app, as the code for the display may be different in the `bslib` package. 
- The simulations that are run depend on the values entered in the equivalent inputs within the Configurations tab, and if these values are changed after running a simulation, the simulation will only change accordingly when the Submit button is clicked again.
- For the CRM simulations, the length of the inputted skeleton must be the same as the number of doses, otherwise the app will crash, displaying a message in the terminal that the dimensions do not match. The current method of entering the skeleton is not how I intend it to be in the final draft - it will be changed once this code is moved over to the restructured app.
- The mean accuracy, duration and overdose values are currently displayed as dataframes with confusing axes titles. This will be changed once the code is moved over to the restructured app.

### What the Screen Should Look Like
This is an example of what the screen should look like after running a simulation:
<img width="1531" height="889" alt="image" src="https://github.com/user-attachments/assets/5c702756-7319-4374-9d59-55d0c553b640" />

## Testing
The reviewer should test this PR by:
- [x] Checking the app opens by using the command `shiny::runApp("app/modules/trial_design")`
- [x] Changing the number of doses or scenarios in the sidebar to make sure the table changes dimensions.
- [x] Adding the true DLTs for a scenario into the table in the Configurations tab.
- [x] Running simulations for no inputs, one input in each category and multiple inputs in each category.
- [x] Changing some of the inputs in the Configurations tab and making sure they change the simulation outputs. 

## Next Steps
The main next steps are:
- [ ] Move this code over to the Trial Design and Simulations tabs of the restructured app, as outlined in #41.
- [ ] Think about the design of the Simulations page in particular - what is the best way to show the results of these simulations?
- [ ] Add a function to plot graphs of the distributions of accuracy, duration and overdose.
- [ ] Think about the Conduct tab.