### PR TITLE
Reactive Questionnaire Variables

### DIFF
--- a/app_skeleton/R/mod_02_questionnaire.R
+++ b/app_skeleton/R/mod_02_questionnaire.R
@@ -117,6 +117,13 @@ mod_questionnaire_server <- function(id, shared) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     
+   # Initialise reactive values
+   shared$q_n_doses <- reactiveVal(numeric(0))
+   shared$q_start_dose <- reactiveVal(numeric(0))
+   shared$q_ttl <- reactiveVal(numeric(0))
+   shared$q_cohort <- reactiveVal(numeric(0))
+   shared$q_max_size <- reactiveVal(numeric(0))
+
     # Load questions data 
     questions <- tryCatch({
       input_directory <- here::here('app_skeleton', 'Inputs')
@@ -279,7 +286,7 @@ mod_questionnaire_server <- function(id, shared) {
     })
     
     question_responses <- reactiveValues(list = vector("list", length = nrow(questions)))
-    
+
     # Next button logic with conditional navigation
     observeEvent(input$next_button, {
       
@@ -440,12 +447,12 @@ mod_questionnaire_server <- function(id, shared) {
         all_question_responses <- question_responses$list # saving set of responses
 
         # Defining shared variables to move to trial design
-        shared$q_n_doses <- as.numeric(all_question_responses[[3]])
-        shared$q_start_dose <- as.numeric(all_question_responses[[4]])
-        shared$q_ttl <- as.numeric(all_question_responses[[7]])
-        shared$q_cohort <- as.numeric(all_question_responses[[12]])
-        shared$q_max_size <- as.numeric(all_question_responses[[14]])
-
+        shared$q_n_doses <- reactive(as.numeric(all_question_responses[[3]]))
+        shared$q_start_dose <- reactive(as.numeric(all_question_responses[[4]]))
+        shared$q_ttl <- reactive(as.numeric(all_question_responses[[7]]))
+        shared$q_cohort <- reactive(as.numeric(all_question_responses[[12]]))
+        shared$q_max_size <- reactive(as.numeric(all_question_responses[[14]]))
+        print(shared$q_start_dose())
       } else {
         shiny::updateActionButton(
           session, 

--- a/app_skeleton/R/mod_02_questionnaire.R
+++ b/app_skeleton/R/mod_02_questionnaire.R
@@ -278,10 +278,20 @@ mod_questionnaire_server <- function(id) {
       }
     })
     
+    question_responses <- reactiveValues(list = list())
+
     # Next button logic with conditional navigation
     observeEvent(input$next_button, {
+      
       # Save current response
-      save_current_response()
+      if(!is.null(current_question())) {
+      current_q_num <- current_question()
+
+      question_response <- questions$q_variable[questions$q_number == current_q_num]
+      question_responses$list[[current_q_num]] <- input[[question_response]]
+
+      print(question_responses$list)
+    }
       
       current_q_num <- current_question()
       

--- a/app_skeleton/R/mod_02_questionnaire.R
+++ b/app_skeleton/R/mod_02_questionnaire.R
@@ -113,7 +113,7 @@ mod_questionnaire_ui <- function(id) {
 #' @param id Module id
 #' 
 #' @noRd 
-mod_questionnaire_server <- function(id) {
+mod_questionnaire_server <- function(id, shared) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     
@@ -278,8 +278,8 @@ mod_questionnaire_server <- function(id) {
       }
     })
     
-    question_responses <- reactiveValues(list = list())
-
+    question_responses <- reactiveValues(list = vector("list", length = nrow(questions)))
+    
     # Next button logic with conditional navigation
     observeEvent(input$next_button, {
       
@@ -290,7 +290,7 @@ mod_questionnaire_server <- function(id) {
       question_response <- questions$q_variable[questions$q_number == current_q_num]
       question_responses$list[[current_q_num]] <- input[[question_response]]
 
-      print(question_responses$list)
+      #print(question_responses$list)
     }
       
       current_q_num <- current_question()
@@ -437,6 +437,15 @@ mod_questionnaire_server <- function(id) {
           "next_button", 
           label = "Generate Recommendation"
         )
+        all_question_responses <- question_responses$list # saving set of responses
+
+        # Defining shared variables to move to trial design
+        shared$q_n_doses <- as.numeric(all_question_responses[[3]])
+        shared$q_start_dose <- as.numeric(all_question_responses[[4]])
+        shared$q_ttl <- as.numeric(all_question_responses[[7]])
+        shared$q_cohort <- as.numeric(all_question_responses[[12]])
+        shared$q_max_size <- as.numeric(all_question_responses[[14]])
+
       } else {
         shiny::updateActionButton(
           session, 

--- a/app_skeleton/R/mod_02_questionnaire.R
+++ b/app_skeleton/R/mod_02_questionnaire.R
@@ -452,7 +452,7 @@ mod_questionnaire_server <- function(id, shared) {
         shared$q_ttl <- reactive(as.numeric(all_question_responses[[7]]))
         shared$q_cohort <- reactive(as.numeric(all_question_responses[[12]]))
         shared$q_max_size <- reactive(as.numeric(all_question_responses[[14]]))
-        print(shared$q_start_dose())
+        #print(shared$q_start_dose())
       } else {
         shiny::updateActionButton(
           session, 

--- a/app_skeleton/app.R
+++ b/app_skeleton/app.R
@@ -39,7 +39,7 @@ server <- function(input, output, session){
     questionnaire_results <- mod_questionnaire_server("questionnaire", shared)
     trial_design_server("trial_design", shared)
     sim_server("simulation", shared)
-    con_server("conduct")
+    con_server("conduct", shared)
 
       observe({
     if (!is.null(questionnaire_results) && 

--- a/app_skeleton/app.R
+++ b/app_skeleton/app.R
@@ -36,7 +36,7 @@ server <- function(input, output, session){
     shared <- reactiveValues()
 
     intro_server("intro")
-    questionnaire_results <- mod_questionnaire_server("questionnaire")
+    questionnaire_results <- mod_questionnaire_server("questionnaire", shared)
     trial_design_server("trial_design", shared)
     sim_server("simulation", shared)
     con_server("conduct")
@@ -62,8 +62,14 @@ shinyApp(ui, server)
 
 ### Defined in trial_design_server ###
 
+# shared$q_n_doses: Number of doses response from questionnaire
+# shared$q_start_dose: Starting dose level response from questionnaire
+# shared$q_ttl: ttl response from questionnaire
+# shared$q_cohort: Cohort size response from questionnaire
+# shared$q_max_size: Maximum sample size response from questionnaire
+
 # shared$n_dosess: Number of doses
-# shared$ttl: Total number of trials
+# shared$ttl: ttl
 # shared$max_size: Maximum sample size
 # shared$start_dose: Starting dose level
 # shared$cohort: Cohort size

--- a/app_skeleton/app.R
+++ b/app_skeleton/app.R
@@ -39,7 +39,7 @@ server <- function(input, output, session){
     questionnaire_results <- mod_questionnaire_server("questionnaire", shared)
     trial_design_server("trial_design", shared)
     sim_server("simulation", shared)
-    con_server("conduct", shared)
+    con_server("conduct")
 
       observe({
     if (!is.null(questionnaire_results) && 

--- a/app_skeleton/pages/global.R
+++ b/app_skeleton/pages/global.R
@@ -81,20 +81,6 @@ validate_numeric_input <- function(value, min_val = NULL, max_val = NULL, intege
 }
 
 # Reusable UI component for numeric input with validation using bslib
-numericInputWithValidation <- function(inputId, label, value = NULL, min = NA, max = NA, 
-                                       step = NA, width = NULL) {
-  div(
-    class = "mb-3",
-    tags$label(label, class = "form-label", `for` = inputId),
-  
-    numericInput(inputId, label = NULL, value = value, min = min, max = max, step = step, width = width),
-    div(
-      id = paste0(inputId, "_warning"), 
-      class = "invalid-feedback d-block",
-      style = "font-size: 0.875rem; margin-top: 0.25rem; min-height: 1.2em;"
-    )
-  )
-}
 
 
 ############################################ Simulation Code ############################################


### PR DESCRIPTION
### What This PR Has Accomplished
- A reactive list called `question_responses` has been created, with 14 empty elements.
- When clicking the next in the questionnaire, the element of `question_responses` corresponding to the current question updates with the user's response.
- If previous is clicked and the response is changed, it will be overwritten with the next button.
- When a recommendation is generated, `question_responses` is saved as `all_question_responses`, and the variables within  `all_question_responses` used in the Trial Design page are saved as shared variables.
- When the user moves over to the Trial Design page and clicks the 'Transfer Questionnaire Results' button in the sidebar, the General Trial Parameters will change to whatever the user entered in the questionnaire. If the result was left blank in the questionnaire, the parameter will remain the same. 

This PR solves most of issue #48 and some of the points raised in issue #41.

### What Still Isn't Working
- The 'next' and 'previous' buttons don't save responses on screen - only in the unseen `question_responses` list. 
- The conditional skipping of questions is wrong.
- There is a lot of code in `mod_02_questionnaire.R` that is not being used, as there are several (unsuccessful) attempts to save the variables. These should probably be deleted or commented out at some point soon. (I would have done it myself in this PR but was worried we would lose something valuable that I didn't know about).
- The method to upload and download questionnaire responses needs to be changed to account for this new method of saving questionnaire responses.

### Testing this PR
1. Without filling in the questionnaire, go to the Trial Designs tab and click the 'Transfer Questionnaire Results' button. Hopefully nothing should happen.
2. Now fill in the questionnaire completely, pressing 'Previous' if needed to find the skipped questions. Generate a recommendation, and then go to the Trial Designs tab and click the 'Transfer Questionnaire Results' button again. Hopefully all results should change to what you entered in the questionnaire.
3. Repeat step 2, entering an incorrect value into a numeric input. Does the warning appear after clicking the the 'Transfer Questionnaire Results' button? (Hopefully it should)
4. Go through the questionnaire again, selecting the default answers. This should skip question 8 (start dose). When clicking the 'Transfer Questionnaire Results' button in the Trial Designs tab, does the number underneath "What is the starting dose level" change? (Hopefully it shouldn't)