### PR TITLE
Fixing the Movement of Questionnaire Results

### DIFF
--- a/app_skeleton/R/mod_02_questionnaire.R
+++ b/app_skeleton/R/mod_02_questionnaire.R
@@ -123,7 +123,7 @@ mod_questionnaire_ui <- function(id) {
 #' @param id Module id
 #' 
 #' @noRd 
-mod_questionnaire_server <- function(id, shared, parent_session = NULL) {
+mod_questionnaire_server <- function(id, shared, move_data, parent_session = NULL) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     
@@ -576,6 +576,9 @@ mod_questionnaire_server <- function(id, shared, parent_session = NULL) {
       # Transfer questionnaire values
       transfer_questionnaire_values()
       
+      # Trigger the transfer function in the Trial Design Module
+      move_data(TRUE)
+
       # Navigate to Simulation tab
       if (!is.null(parent_session)) {
         updateNavbarPage(parent_session, "nav", selected = "Simulation")
@@ -596,7 +599,10 @@ mod_questionnaire_server <- function(id, shared, parent_session = NULL) {
     observeEvent(input$advanced_settings, {
       # Transfer questionnaire values
       transfer_questionnaire_values()
-      
+
+      # Trigger the transfer function in the Trial Design Module
+      move_data(TRUE)
+
       # Navigate to Trial Design tab
       if (!is.null(parent_session)) {
         updateNavbarPage(parent_session, "nav", selected = "Trial Design")

--- a/app_skeleton/app.R
+++ b/app_skeleton/app.R
@@ -33,14 +33,17 @@ ui <- navbarPage(
 
 # Define server logic
 server <- function(input, output, session){
-    # Defining a shared reactive variable for n_doses
+    # Defining Buttons that move data between tabs
+    move_data <- reactiveVal(FALSE)
+
+    # Defining shared reactive variables
     shared <- reactiveValues()
 
     intro_server("intro", session)
-    questionnaire_results <- mod_questionnaire_server("questionnaire", shared, session)
-    trial_design_server("trial_design", shared)
+    questionnaire_results <- mod_questionnaire_server("questionnaire", shared, session, move_data = move_data)
+    trial_design_server("trial_design", shared, move_data = move_data)
     sim_server("simulation", shared)
-    con_server("conduct")
+    con_server("conduct", shared)
 
       observe({
     if (!is.null(questionnaire_results) && 

--- a/app_skeleton/pages/con_ui.R
+++ b/app_skeleton/pages/con_ui.R
@@ -18,7 +18,7 @@ con_ui <- function(id) {
   )
 }
 
-con_server <- function(id) {
+con_server <- function(id, shared) {
   moduleServer(id, function(input, output, session) {
     # Placeholder logic
   })

--- a/app_skeleton/pages/sim_ui.R
+++ b/app_skeleton/pages/sim_ui.R
@@ -24,7 +24,7 @@ sim_ui <- function(id) {
 
   # Running the tab itself
   page_sidebar(
-     card(height = 250,
+     card(height = 600,
       card_header("Simulation Inputs"),
       card_body(
       simulation_inputs,
@@ -32,6 +32,7 @@ sim_ui <- function(id) {
       in the table below. If the dimensions do not match, change the number of scenarios and doses and press 
       'Refresh Dimensions'."),
       test_df_table,
+      tags$hr(), # Separator line
       input_task_button(ns("refresh_table_input"), "Refresh Table Dimensions")
       )),
       card(
@@ -75,7 +76,7 @@ sim_ui <- function(id) {
       p("Want to save your simulation results? Click a button below to download them as a CSV file."),
       downloadButton(ns("download_simulation_results"), "Download Simulation Results")
     )
-  ) 
+  )
 }
 
 sim_server <- function(id, shared) {

--- a/app_skeleton/pages/trial_design_ui.R
+++ b/app_skeleton/pages/trial_design_ui.R
@@ -137,12 +137,45 @@ choices = c("Yes" = TRUE, "No" = FALSE), selected = TRUE, inline = TRUE)
     )
 }
 
-trial_design_server <- function(id, shared) {
+trial_design_server <- function(id, shared, move_data) {
   moduleServer(id, function(input, output, session) {
 
 ################## Questionnaire Inputs ##################    
-# Transfer logic removed - now handled in questionnaire modal navigation
+# There needs to be logic here to trasnfer data - I have taken this directly from the old Transfer Results From Questionnaire button.
+observeEvent(move_data(), {
+# Transfer questionnaire results to trial design inputs
+  if (length(shared$q_n_doses()) > 0) {
+    updateNumericInput(session, "n_doses_inputt", value = shared$q_n_doses())
+  } else {
+    updateNumericInput(session, "n_doses_inputt", value = 5) # Default value if not set
+  }
+  if (length(shared$q_ttl()) > 0) {
+    updateNumericInput(session, "ttl_inputt", value = shared$q_ttl())
+  } else {
+    updateNumericInput(session, "ttl_inputt", value = 0.3) # Default value if not set
+  }
+  if (length(shared$q_max_size()) > 0) {
+    updateNumericInput(session, "max_size_inputt", value = shared$q_max_size())
+  }
+  else {
+    updateNumericInput(session, "max_size_inputt", value = 30) # Default value if not set
+  }
+  if (length(shared$q_start_dose()) > 0) {
+    updateNumericInput(session, "start_dose_inputt", value = shared$q_start_dose())
+  }
+  else {
+    updateNumericInput(session, "start_dose_inputt", value = 1) # Default value if not set
+  }
+  if (length(shared$q_cohort()) > 0) {
+    updateNumericInput(session, "cohort_inputt", value = shared$q_cohort())
+  }
+  else {
+    updateNumericInput(session, "cohort_inputt", value = 3) # Default value if not set
+  }
 
+  # Need to make move_data FALSE again so that it doesn't keep transferring data
+  move_data(FALSE)
+})
     #################################### From Configurations Tab Server #####################################
 
  ######################################## Configuration tab's file upload/download ########################################


### PR DESCRIPTION
This PR is short (one commit) and consists of a fix to the function that moves data from the completed questionnaire to the Trial Designs tab within the new framework, after clicking either 'Go to Simulation' or 'Advanced Settings'. 

### Testing this PR
1. Fill in the questionnaire and click 'Advanced Settings'. Do the general inputs in the Trial Designs tab change?
2. Fill in the questionnaire and click 'Go to Simulation'. Do the general inputs in the Trial Designs tab change?