### PR TITLE
Fixing the Issues in #67

### DIFF
--- a/app_skeleton/app.R
+++ b/app_skeleton/app.R
@@ -75,7 +75,7 @@ shinyApp(ui, server)
 # shared$ttl: ttl
 # shared$max_size: Maximum sample size
 # shared$start_dose: Starting dose level
-# shared$cohort: Cohort size
+# shared$cohort_size: Cohort size
 
 # shared$skip_esc_crm: Skip escalation in CRM
 # shared$skip_deesc_crm: Skip de-escalation in CRM

--- a/app_skeleton/pages/global.R
+++ b/app_skeleton/pages/global.R
@@ -183,7 +183,6 @@ mean_length$tpt <- mean(dist_length$tpt)
 output <- list(
     selection_tab = selection_tab$tpt, # % Times dose was selected as MTD
     treatment_tab = treatment_tab$tpt, # % Treated at each dose
-    dist_accuracy = dist_accuracy$tpt, # Distribution of accuracy
     mean_accuracy = mean_accuracy$tpt, # Mean accuracy
     dist_overdose = dist_overdose$tpt, # Distribution of overdose
     mean_overdose = mean_overdose$tpt, # Mean overdose
@@ -294,7 +293,6 @@ mean_length$crm <- mean(dist_length$crm)
 output <- list(
     selection_tab = selection_tab$crm, # % Times dose was selected as MTD
     treatment_tab = treatment_tab$crm, # % Treated at each dose
-    dist_accuracy = dist_accuracy$crm, # Distribution of accuracy
     mean_accuracy = mean_accuracy$crm, # Mean accuracy
     dist_overdose = dist_overdose$crm, # Distribution of overdose
     mean_overdose = mean_overdose$crm, # Mean overdose
@@ -377,7 +375,6 @@ mean_length <- mean(dist_length)
 output <- list(
     selection_tab = selection_tab, # % Times dose was selected as MTD
     treatment_tab = treatment_tab, # % Treated at each dose
-    dist_accuracy = dist_accuracy, # Distribution of accuracy
     mean_accuracy = mean_accuracy, # Mean accuracy
     dist_overdose = dist_overdose, # Distribution of overdose
     mean_overdose = mean_overdose, # Mean overdose
@@ -547,7 +544,6 @@ plot_dist <- function(data, category, mean_vector, title, x_title, col, model_pi
   output <- list(
     data_selection = data_selection,
     data_treatment = data_treatment,
-    accuracy = data.frame(accuracy = sim$dist_accuracy),
     #mean_accuracy = as.numeric(sim$mean_accuracy),
     overdose = data.frame(overdose = sim$dist_overdose),
     #mean_overdose = as.numeric(sim$mean_overdose),

--- a/app_skeleton/pages/global.R
+++ b/app_skeleton/pages/global.R
@@ -574,3 +574,50 @@ plot_dist <- function(data, category, mean_vector, title, x_title, col, model_pi
   mean_scen <- lapply(seq_along(mean[[1]]), function(j) sapply(mean, `[`, j))
   return(mean_scen)
   }
+
+  ############### Functions to Output Example Scenarios ################
+
+  ### Function for logistic models.
+  logistic_scenarios <- function(pT, MTD, delta, n_doses, a) {
+    d <- rep(NA, n_doses)
+      d[MTD] <- log(pT/(1-pT)) - a 
+
+      G1 <- (log(pT + delta)/(1-(pT + delta)) - a)
+      G2 <- (log(pT - delta)/(1-(pT - delta)) - a)
+
+      Gplus <- G1/G2
+      Gminus <- G2/G1
+
+      for (i in MTD:(n_doses - 1)) {
+        d[i+1] <- Gplus * d[i]
+      }
+      for (i in MTD:2) {
+        d[i-1] <- Gminus * d[i]
+      }
+      for (i in 1:n_doses) {
+        p[i] <- exp(a + d[i])/(1 + exp(a + d[i]))
+      }
+    return(p)
+  }
+
+  # For now, I will take a fixed delta (0.05). This can be refined later.
+  example_scenarios <- function (pT, MTD, delta, n_doses, F) {
+    p <- rep(NA, n_doses)
+    p[MTD] <- pT
+
+    if (F == 1) { # Based on the empiric dose-toxicity model
+      for (i in MTD:(n_doses-1)) {
+        p[i+1] <- exp((log(pT + delta)*log(p[i]))/(log(pT - delta)))
+      }
+      for (i in MTD:2) {
+        p[i-1] <- exp((log(pT - delta)*log(p[i]))/(log(pT + delta)))
+      }
+    } else if (F == 2) { # Based on the 1 parametric logistical dose-toxicity model with a = 3
+      p <- logistic_scenarios(pT, MTD, delta, n_doses, a = 3)
+    } else if (F == 3) { # Based on the 2 parametric logistical dose-toxicity model.
+      p <- logistic_scenarios(pT, MTD, delta, n_doses, a = 0)
+    } else {p  = NULL}
+
+    return(p)
+  }
+ 

--- a/app_skeleton/pages/global.R
+++ b/app_skeleton/pages/global.R
@@ -454,7 +454,7 @@ plot_bar <- function(data, category, value, title, y_title, col, model_picked, m
 
 
 ########################### Function to Format Data for Plot Simulation Histograms ###########################
-plot_dist <- function(data, category, mean_vector, title, x_title, col, model_picked, models, scenarios) {
+plot_dist <- function(data, category, median_vector, title, x_title, col, model_picked, models, scenarios) {
   
   valid_data <- Filter(Negate(is.null), data)
 
@@ -464,9 +464,9 @@ plot_dist <- function(data, category, mean_vector, title, x_title, col, model_pi
   scenario <- c("Scenario 1", "Scenario 2", "Scenario 3") # For later when "by scenario" is implemented
   updated_scenarios <- scenario[!sapply(scenarios, identical, FALSE)]
 
-  Mean <- mean_vector
+  Median <- median_vector
 
-  mean <- data.frame(Mean)
+  median <- data.frame(Median)
 
   if (length(valid_data) == 0) {
     return(NULL)
@@ -497,23 +497,23 @@ plot_dist <- function(data, category, mean_vector, title, x_title, col, model_pi
   combined_data <- do.call(rbind, named_data)
 
    if (model_picked == 1) {
-    mean$model <- updated_model
- 
+    median$model <- updated_model
+
     fill_col <- combined_data$Model
-    colour <- mean$model
+    colour <- median$model
     fill_title <- "Model"
   } else {
-     mean$scenarios <- updated_scenarios
+     median$scenarios <- updated_scenarios
 
     fill_col <- combined_data$Scenario
-    colour <- mean$scenarios
+    colour <- median$scenarios
     fill_title <- "Scenario"
   }
 
   plot <- ggplot(combined_data, aes(x = {{category}}, fill = fill_col)) +
      geom_density(alpha=0.3) +
-     geom_vline(data = mean, aes(xintercept = Mean, color = colour), linetype = "dashed") + 
-     labs(title = title, x = x_title, y = "Density", color = "Mean Values", fill = fill_title) +
+     geom_vline(data = median, aes(xintercept = Median, color = colour), linetype = "dashed") + 
+     labs(title = title, x = x_title, y = "Density", color = "Median Values", fill = fill_title) +
     theme_minimal()
 
     return(plot)
@@ -570,9 +570,9 @@ plot_dist <- function(data, category, mean_vector, title, x_title, col, model_pi
   return(list2)
 }
 
-  mean_for_scen <- function(mean) {
-  mean_scen <- lapply(seq_along(mean[[1]]), function(j) sapply(mean, `[`, j))
-  return(mean_scen)
+  median_for_scen <- function(median) {
+  median_scen <- lapply(seq_along(median[[1]]), function(j) sapply(median, `[`, j))
+  return(median_scen)
   }
 
   ############### Functions to Output Example Scenarios ################

--- a/app_skeleton/pages/global.R
+++ b/app_skeleton/pages/global.R
@@ -560,7 +560,7 @@ plot_dist <- function(data, category, mean_vector, title, x_title, col, model_pi
   }
  
   for (i in 1:3) {
-    for (j in 1:5) {
+    for (j in 1:4) {
     if (is.null(list1[[i]][[j]])) {
       list2[[j]][[i]] <- list(NULL)
     } else {

--- a/app_skeleton/pages/global.R
+++ b/app_skeleton/pages/global.R
@@ -511,9 +511,9 @@ plot_dist <- function(data, category, mean_vector, title, x_title, col, model_pi
   }
 
   plot <- ggplot(combined_data, aes(x = {{category}}, fill = fill_col)) +
-     geom_histogram(binwidth = 1, position = position_dodge(), color = "black") +
-     geom_vline(data = mean, aes(xintercept = Mean, color = colour), linetype = "dashed") + # Mean fixed for now
-     labs(title = title, x = x_title, y = "Frequency", color = "Mean Values", fill = fill_title) +
+     geom_density(alpha=0.3) +
+     geom_vline(data = mean, aes(xintercept = Mean, color = colour), linetype = "dashed") + 
+     labs(title = title, x = x_title, y = "Density", color = "Mean Values", fill = fill_title) +
     theme_minimal()
 
     return(plot)

--- a/app_skeleton/pages/sim_ui.R
+++ b/app_skeleton/pages/sim_ui.R
@@ -361,9 +361,11 @@ ns <- session$ns
 
   tables_and_titles <- renderUI({ generate_tables_ui })
 
-  if ("Individually" %in% input$comparative_view) {
+  if ("Individually" %in% input$comparative_view | n_data_frames == 1) {
     output$tables_ui <- tables_and_titles
 
+    output$titles1 <- NULL
+    output$titles2 <- NULL
     output$tables1 <- NULL
     output$tables2 <- NULL
     output$buttons1 <- NULL

--- a/app_skeleton/pages/sim_ui.R
+++ b/app_skeleton/pages/sim_ui.R
@@ -38,7 +38,15 @@ sim_ui <- function(id) {
           nav_panel(
             "Simulation Output - Tables",
             h3("Simulation Output - Tables"),
-            uiOutput(ns("tables_ui"))
+            tags$hr(),
+            uiOutput(ns("tables_ui")), # Individual view
+            textOutput(ns("titles1")),
+            tableOutput(ns("tables1")),
+            uiOutput(ns("buttons1")),
+            tags$hr(),
+            textOutput(ns("titles2")),
+            tableOutput(ns("tables2")),
+            uiOutput(ns("buttons2"))
           ),
           nav_panel("Simulation Output - Plots",
           h3("Simulation Output - Plots"),
@@ -151,6 +159,9 @@ ns <- session$ns
  ######################################### Simulation Outputs #########################################
  # Code copied directly from the trial_design tab's server code
  # Simulation outputs
+
+ sim_df <- reactiveVal(NULL) # initialising
+ sim_titles <- reactiveVal(NULL) # initialising
 
   observeEvent(input$run_simulation, {
     # Adding in Scenarios. I am going to cap the possible number of Scenarios to 3 (this can be changed later).
@@ -352,8 +363,40 @@ ns <- session$ns
 
   if ("Individually" %in% input$comparative_view) {
     output$tables_ui <- tables_and_titles
-  } else {output$tables_ui <- NULL}
 
+    output$tables1 <- NULL
+    output$tables2 <- NULL
+    output$buttons1 <- NULL
+    output$buttons2 <- NULL
+
+
+  } else {output$tables_ui <- NULL
+
+  output$titles1 <- renderText({combined_titles[[1]]})
+  output$titles2 <- renderText({combined_titles[[2]]})
+  output$tables1 <- renderTable({combined_data_frames[[1]]}, rownames = TRUE, colnames = TRUE)
+  output$tables2 <- renderTable({combined_data_frames[[2]]}, rownames = TRUE, colnames = TRUE)
+
+  output$buttons1 <- renderUI({
+    if (n_data_frames > 0) {
+      tagList(
+        actionButton(ns("prev1"), "Previous", class = "btn btn-secondary"),
+        actionButton(ns("next1"), "Next", class = "btn btn-secondary")
+      )
+    }
+  })
+  output$buttons2 <- renderUI({
+    if (n_data_frames > 1) {
+      tagList(
+        actionButton(ns("prev2"), "Previous", class = "btn btn-secondary"),
+        actionButton(ns("next2"), "Next", class = "btn btn-secondary")
+      )
+    }
+  })
+
+  sim_df <- sim_df(combined_data_frames) 
+  sim_titles <- sim_titles(combined_titles) # Updating the reactive values with the new data frames and titles
+  }
   ########################## Plots #####################################
 
   # Focusing on "by model" 
@@ -494,6 +537,59 @@ ns <- session$ns
   } # else (after for loop)
   } # else (before for loop)
   }) # observe function
+
+ current_table1 <- reactiveVal(1)
+ current_table2 <- reactiveVal(2)
+
+  observeEvent(input$hehe, {
+    # This is to test the combined df
+  })
+
+  observeEvent(input$next1, {
+    if (current_table1() < length(sim_df())) {
+      current_table1(current_table1() + 1)
+      output$tables1 <- renderTable({
+        sim_df()[[current_table1()]]
+      }, rownames = TRUE, colnames = TRUE)
+      output$titles1 <- renderText({
+        sim_titles()[[current_table1()]]
+      })
+    } 
+  })
+  observeEvent(input$prev1, {
+    if (current_table1() > 1) {
+      current_table1(current_table1() - 1)
+      output$tables1 <- renderTable({
+        sim_df()[[current_table1()]]
+      }, rownames = TRUE, colnames = TRUE)
+      output$titles1 <- renderText({
+        sim_titles()[[current_table1()]]
+      })
+    } 
+  })
+  observeEvent(input$next2, {
+    if (current_table2() < length(sim_df())) {
+      current_table2(current_table2() + 1)
+      output$tables2 <- renderTable({
+        sim_df()[[current_table2()]]
+      }, rownames = TRUE, colnames = TRUE)
+      output$titles2 <- renderText({
+        sim_titles()[[current_table2()]]
+      })
+    } 
+  })
+  observeEvent(input$prev2, {
+    if (current_table2() > 1) {
+      current_table2(current_table2() - 1)
+      output$tables2 <- renderTable({
+        sim_df()[[current_table2()]]
+      }, rownames = TRUE, colnames = TRUE)
+      output$titles2 <- renderText({
+        sim_titles()[[current_table2()]]
+      })
+    } 
+  })
+
 
   }) # End of moduleServer
 } # End of sever function

--- a/app_skeleton/pages/sim_ui.R
+++ b/app_skeleton/pages/sim_ui.R
@@ -207,10 +207,10 @@ ns <- session$ns
   plot_tpt <- vector("list", n_scen) # initialising for use later
   plot_crm <- vector("list", n_scen) # initialising for use later
   plot_boin <- vector("list", n_scen) # initialising for use later
-  mean_accuracy <- vector("list", n_scen) # initialising for use later
-  mean_overdose <- vector("list", n_scen) # initialising for use later
-  mean_length <- vector("list", n_scen) # initialising for use later
-  
+  median_accuracy <- vector("list", n_scen) # initialising for use later
+  median_overdose <- vector("list", n_scen) # initialising for use later
+  median_length <- vector("list", n_scen) # initialising for use later
+
    # Metric - putting it outside of the for loop so only one list is created.
   selected_metric <- cbind(
   selected_mtd <- {"% times dose was selected as MTD" %in% input$metric_selection_input},
@@ -237,12 +237,17 @@ ns <- session$ns
       tpt_mean_overdose <- tpt_sim$mean_overdose
       tpt_mean_length <- tpt_sim$mean_length
 
+      tpt_median_overdose <- median(tpt_sim$dist_overdose)
+      tpt_median_length <- median(tpt_sim$dist_length)
+
       tpt_for_plots <- data_for_plotting(tpt_sim, shared$ttl())
       } else {tpt_modified_tab <- NULL
       tpt_for_plots <- rep(list(NULL), 5)
       tpt_mean_accuracy <- NULL
       tpt_mean_overdose <- NULL
       tpt_mean_length <- NULL
+      tpt_median_overdose <- NULL
+      tpt_median_length <- NULL
       }
 
   if ("CRM" %in% input$simulation_design_selection_input)
@@ -261,12 +266,18 @@ ns <- session$ns
       crm_mean_overdose <- crm_sim$mean_overdose
       crm_mean_length <- crm_sim$mean_length
 
+      crm_median_overdose <- median(crm_sim$dist_overdose)
+      crm_median_length <- median(crm_sim$dist_length)
+
       crm_for_plots <- data_for_plotting(crm_sim, shared$ttl())
       } else {crm_modified_tab <- NULL
       crm_for_plots <- rep(list(NULL), 5)
       crm_mean_accuracy <- NULL
       crm_mean_overdose <- NULL
-      crm_mean_length <- NULL}
+      crm_mean_length <- NULL
+      crm_median_overdose <- NULL
+      crm_median_length <- NULL
+      }
 
    if ("BOIN" %in% input$simulation_design_selection_input)
       { boin_sim <- sim_boin(shared$n_dosess(), shared$ttl(), shared$max_size(), shared$start_dose(), n_sims(), unlist(used_true_dlts[j, ]), shared$boin_cohorts(), shared$stop_n_mtd_boin(), p_tox =  shared$phi_2, p_saf =  shared$phi_1, TRUE, 10) # testing with hard-coded values for now
@@ -283,12 +294,17 @@ ns <- session$ns
       boin_mean_overdose <- boin_sim$mean_overdose
       boin_mean_length <- boin_sim$mean_length
 
+      boin_median_overdose <- median(boin_sim$dist_overdose)
+      boin_median_length <- median(boin_sim$dist_length)
+
       boin_for_plots <- data_for_plotting(boin_sim, shared$ttl())
       } else {boin_modified_tab <- NULL
       boin_for_plots <- rep(list(NULL), 5)
       boin_mean_accuracy <- NULL
       boin_mean_overdose <- NULL
       boin_mean_length <- NULL
+      boin_median_overdose <- NULL
+      boin_median_length <- NULL
       }
 
   # Giving Titles to Single Value Outputs
@@ -340,9 +356,11 @@ ns <- session$ns
   plot_crm[[j]] <- crm_for_plots
   plot_boin[[j]] <- boin_for_plots
 
-  mean_accuracy[[j]] <- c(tpt_mean_accuracy, crm_mean_accuracy, boin_mean_accuracy)
-  mean_overdose[[j]] <- c(tpt_mean_overdose, crm_mean_overdose, boin_mean_overdose)
-  mean_length[[j]] <- c(tpt_mean_length, crm_mean_length, boin_mean_length)
+  #mean_accuracy[[j]] <- c(tpt_mean_accuracy, crm_mean_accuracy, boin_mean_accuracy)
+  #mean_overdose[[j]] <- c(tpt_mean_overdose, crm_mean_overdose, boin_mean_overdose)
+  #mean_length[[j]] <- c(tpt_mean_length, crm_mean_length, boin_mean_length)
+  median_overdose[[j]] <- c(tpt_median_overdose, crm_median_overdose, boin_median_overdose)
+  median_length[[j]] <- c(tpt_median_length, crm_median_length, boin_median_length)
   } # for loop end
 
 ## Tables
@@ -426,8 +444,8 @@ ns <- session$ns
 
    for (j in 1:n_scen) {
     data <- plot_list[[j]]   #plot_list[[j]][[k]] = Scenario j, Metric k.
-    mo <- mean_overdose[[j]]
-    ml <- mean_length[[j]]
+    mo <- median_overdose[[j]]
+    ml <- median_length[[j]]
 
     for (k in 1:4) {
       met <- data[[k]]
@@ -499,9 +517,8 @@ ns <- session$ns
 
   plot_list_by_scenario <- list(tpt_by_scenario, crm_by_scenario, boin_by_scenario)
 
-  mean_acc_scen <- mean_for_scen(mean_accuracy)
-  mean_ov_scen <- mean_for_scen(mean_overdose)
-  mean_len_scen <- mean_for_scen(mean_length)
+  median_ov_scen <- median_for_scen(median_overdose)
+  median_len_scen <- median_for_scen(median_length)
 
     updated_model <- model[!sapply(selected_models, identical, FALSE)] 
 
@@ -512,8 +529,8 @@ ns <- session$ns
    for (j in 1:n_models) {
     data <- used_plots[[j]] 
   
-    mo <- mean_ov_scen[[j]]
-    ml <- mean_len_scen[[j]]
+    mo <- median_ov_scen[[j]]
+    ml <- median_len_scen[[j]]
 
     for (k in 1:4) {
       met <- data[[k]]

--- a/app_skeleton/pages/sim_ui.R
+++ b/app_skeleton/pages/sim_ui.R
@@ -360,6 +360,7 @@ ns <- session$ns
   ########################## Plots #####################################
 
   # Focusing on "by model" 
+  metric_no_accuracy <- selected_metric[-3] # Removing accuracy from the list of selected metrics
 
   if ("By Model" %in% input$display_plots) {
   graphs <- vector("list", 4*n_scen) # initialising for use later
@@ -373,7 +374,7 @@ ns <- session$ns
       met <- data[[k]]
 
       if(is.null(met)) 
-      { next } else if (selected_metric[k] == FALSE) { next
+      { next } else if (metric_no_accuracy[k] == FALSE) { next
       } else if (!is.null(met[[1]]$selection) | !is.null(met[[2]]$selection) | !is.null(met[[3]]$selection)) {
       graphs[[4*(j-1) + k]] <- plot_bar(met, Dose, selection, title = paste("% Times Dose Was Selected as MTD for", updated_scenarios[[j]]), y_title = "% Times Dose Was Selected as MTD", col = "blue", model_picked = 1, models = selected_models, scenarios = selected_scenarios) # Using blue for MTD
       } else if (!is.null(met[[1]]$treatment) | !is.null(met[[2]]$treatment) | !is.null(met[[3]]$treatment)) {
@@ -455,11 +456,11 @@ ns <- session$ns
     mo <- mean_ov_scen[[j]]
     ml <- mean_len_scen[[j]]
 
-    for (k in 1:5) {
+    for (k in 1:4) {
       met <- data[[k]]
       
       if(is.null(met)) 
-      { next } else if (selected_metric[k] == FALSE) { next
+      { next } else if (metric_no_accuracy[k] == FALSE) { next
       } else if (!is.null(met[[1]]$selection) | !is.null(met[[2]]$selection) | !is.null(met[[3]]$selection)) {
       graphs[[4*(j-1) + k]] <- plot_bar(met, Dose, selection, title = paste("% Times Dose Was Selected as MTD for", updated_model[j]), y_title = "% Times Dose Was Selected as MTD", col = "blue", model_picked = 2, models = selected_models, scenarios = selected_scenarios) # Using blue for MTD
       } else if (!is.null(met[[1]]$treatment) | !is.null(met[[2]]$treatment) | !is.null(met[[3]]$treatment)) {

--- a/app_skeleton/pages/sim_ui.R
+++ b/app_skeleton/pages/sim_ui.R
@@ -201,7 +201,7 @@ ns <- session$ns
   # Design - only running simulations that are necessary to save time.
   if ("3+3" %in% input$simulation_design_selection_input)
       { tpt_sim <- sim_tpt(shared$n_dosess(), shared$ttl(), shared$max_size(), shared$start_dose(), n_sims(), unlist(used_true_dlts[j, ]), shared$skip_tpt(), 12345)
-       tpt_modified_tab <- tpt_sim[-c(3,5,7)]
+       tpt_modified_tab <- tpt_sim[-c(4,6)]
 
       tpt_modified_tab$mean_accuracy <- as.data.frame(tpt_modified_tab$mean_accuracy, row.names = "Mean Accuracy")
       tpt_modified_tab$mean_overdose <- as.data.frame(tpt_modified_tab$mean_overdose, row.names = "Mean Overdose")
@@ -224,7 +224,7 @@ ns <- session$ns
 
   if ("CRM" %in% input$simulation_design_selection_input)
       { crm_sim <- sim_crm(shared$n_dosess(), shared$ttl(), shared$max_size(), shared$start_dose(), n_sims(), unlist(used_true_dlts[j, ]), shared$skeleton_crm(), shared$prior_var_crm(), shared$skip_esc_crm(), shared$skip_deesc_crm(), shared$stop_tox_x_crm(), shared$stop_tox_y_crm(), shared$stop_n_mtd_crm())
-      crm_modified_tab <- crm_sim[-c(3,5,7)]
+      crm_modified_tab <- crm_sim[-c(4,6)]
   
 
       crm_modified_tab$mean_accuracy <- as.data.frame(crm_modified_tab$mean_accuracy, row.names = "Mean Accuracy", col.names = FALSE)
@@ -246,8 +246,8 @@ ns <- session$ns
       crm_mean_length <- NULL}
 
    if ("BOIN" %in% input$simulation_design_selection_input)
-      { boin_sim <- sim_boin(shared$n_dosess(), shared$ttl(), shared$max_size(), shared$start_dose(), n_sims(), unlist(used_true_dlts[j, ]), shared$boin_cohorts(), shared$stop_n_mtd_boin(), shared$phi_2(), shared$phi_1(), TRUE, 10) # testing with hard-coded values for now
-       boin_modified_tab <- boin_sim[-c(3,5,7)]
+      { boin_sim <- sim_boin(shared$n_dosess(), shared$ttl(), shared$max_size(), shared$start_dose(), n_sims(), unlist(used_true_dlts[j, ]), shared$boin_cohorts(), shared$stop_n_mtd_boin(), p_tox =  shared$phi_2, p_saf =  shared$phi_1, TRUE, 10) # testing with hard-coded values for now
+       boin_modified_tab <- boin_sim[-c(4,6)]
 
       boin_modified_tab$mean_accuracy <- as.data.frame(boin_modified_tab$mean_accuracy, row.names = "Mean Accuracy")
       boin_modified_tab$mean_overdose <- as.data.frame(boin_modified_tab$mean_overdose, row.names = "Mean Overdose")
@@ -280,10 +280,10 @@ ns <- session$ns
   scenario_number <- as.character(rep(updated_scenarios[[j]], 5))
   metric_names <- as.character(c(" - % Times Dose Was Selected as MTD", "- % Treated at Each Dose",  " - Mean Accuracy", " - Mean Overdose", " - Mean Trial Length"))
 
-  sim_list <- vector("list", 5) # initialising for use later
+  sim_list <- vector("list", 4) # initialising for use later
 
   # Organising plot lists by metric
-  for (k in 1:5) {
+  for (k in 1:4) {
     sim_list[[k]] <- list(tpt_for_plots[[k]], crm_for_plots[[k]], boin_for_plots[[k]])
   }
 
@@ -362,31 +362,28 @@ ns <- session$ns
   # Focusing on "by model" 
 
   if ("By Model" %in% input$display_plots) {
-  graphs <- vector("list", 5*n_scen) # initialising for use later
+  graphs <- vector("list", 4*n_scen) # initialising for use later
 
    for (j in 1:n_scen) {
     data <- plot_list[[j]]   #plot_list[[j]][[k]] = Scenario j, Metric k.
-    ma <- mean_accuracy[[j]]
     mo <- mean_overdose[[j]]
     ml <- mean_length[[j]]
 
-    for (k in 1:5) {
+    for (k in 1:4) {
       met <- data[[k]]
 
       if(is.null(met)) 
       { next } else if (selected_metric[k] == FALSE) { next
       } else if (!is.null(met[[1]]$selection) | !is.null(met[[2]]$selection) | !is.null(met[[3]]$selection)) {
-      graphs[[5*(j-1) + k]] <- plot_bar(met, Dose, selection, title = paste("% Times Dose Was Selected as MTD for", updated_scenarios[[j]]), y_title = "% Times Dose Was Selected as MTD", col = "blue", model_picked = 1, models = selected_models, scenarios = selected_scenarios) # Using blue for MTD
+      graphs[[4*(j-1) + k]] <- plot_bar(met, Dose, selection, title = paste("% Times Dose Was Selected as MTD for", updated_scenarios[[j]]), y_title = "% Times Dose Was Selected as MTD", col = "blue", model_picked = 1, models = selected_models, scenarios = selected_scenarios) # Using blue for MTD
       } else if (!is.null(met[[1]]$treatment) | !is.null(met[[2]]$treatment) | !is.null(met[[3]]$treatment)) {
-      graphs[[5*(j-1) + k]] <- plot_bar(met, Dose_Level, treatment, title = paste("% Treated at Dose for", updated_scenarios[[j]]), y_title = "% Treated at Dose", col = "blue", model_picked = 1, models = selected_models, scenarios = selected_scenarios) # Using blue for MTD
-      } else if (!is.null(met[[1]]$accuracy) | !is.null(met[[2]]$accuracy) | !is.null(met[[3]]$accuracy)) {
-      graphs[[5*(j-1) + k]] <- plot_dist(met, accuracy, ma, title = paste("Distribution of Accuracy for", updated_scenarios[[j]]), x_title = "Accuracy", col = "blue", model_picked = 1, models = selected_models, scenarios = selected_scenarios) # Using blue for mean
+      graphs[[4*(j-1) + k]] <- plot_bar(met, Dose_Level, treatment, title = paste("% Treated at Dose for", updated_scenarios[[j]]), y_title = "% Treated at Dose", col = "blue", model_picked = 1, models = selected_models, scenarios = selected_scenarios) # Using blue for MTD
       } else if (!is.null(met[[1]]$overdose) | !is.null(met[[2]]$overdose) | !is.null(met[[3]]$overdose)) {
-      graphs[[5*(j-1) + k]] <- plot_dist(met, overdose, mo, title = paste("Distribution of Overdoses for", updated_scenarios[[j]]), x_title = "Overdose", col = "blue", model_picked = 1, models = selected_models, scenarios = selected_scenarios) # Using blue for mean
+      graphs[[4*(j-1) + k]] <- plot_dist(met, overdose, mo, title = paste("Distribution of Overdoses for", updated_scenarios[[j]]), x_title = "Overdose", col = "blue", model_picked = 1, models = selected_models, scenarios = selected_scenarios) # Using blue for mean
       } else if (!is.null(met[[1]]$length) | !is.null(met[[2]]$length) | !is.null(met[[3]]$length)) {
-      graphs[[5*(j-1) + k]] <- plot_dist(met, length, ml, title = paste("Distribution of Trial Duration for", updated_scenarios[[j]]), x_title = "Trial Duration", col = "blue", model_picked = 1, models = selected_models, scenarios = selected_scenarios) # Using blue for mean
+      graphs[[4*(j-1) + k]] <- plot_dist(met, length, ml, title = paste("Distribution of Trial Duration for", updated_scenarios[[j]]), x_title = "Trial Duration", col = "blue", model_picked = 1, models = selected_models, scenarios = selected_scenarios) # Using blue for mean
       } else {
-        graphs[[5*(j-1) + k]] <- NULL
+        graphs[[4*(j-1) + k]] <- NULL
       } # Using fixed values for means for now
     }
    }
@@ -448,14 +445,13 @@ ns <- session$ns
 
     updated_model <- model[!sapply(selected_models, identical, FALSE)] 
 
-    graphs <- vector("list", 5*n_models) # initialising for use later
+    graphs <- vector("list", 4*n_models) # initialising for use later
 
     used_plots <- plot_list_by_scenario[!sapply(selected_models, identical, FALSE)] 
 
    for (j in 1:n_models) {
     data <- used_plots[[j]] 
   
-    ma <- mean_acc_scen[[j]]
     mo <- mean_ov_scen[[j]]
     ml <- mean_len_scen[[j]]
 
@@ -465,17 +461,15 @@ ns <- session$ns
       if(is.null(met)) 
       { next } else if (selected_metric[k] == FALSE) { next
       } else if (!is.null(met[[1]]$selection) | !is.null(met[[2]]$selection) | !is.null(met[[3]]$selection)) {
-      graphs[[5*(j-1) + k]] <- plot_bar(met, Dose, selection, title = paste("% Times Dose Was Selected as MTD for", updated_model[j]), y_title = "% Times Dose Was Selected as MTD", col = "blue", model_picked = 2, models = selected_models, scenarios = selected_scenarios) # Using blue for MTD
+      graphs[[4*(j-1) + k]] <- plot_bar(met, Dose, selection, title = paste("% Times Dose Was Selected as MTD for", updated_model[j]), y_title = "% Times Dose Was Selected as MTD", col = "blue", model_picked = 2, models = selected_models, scenarios = selected_scenarios) # Using blue for MTD
       } else if (!is.null(met[[1]]$treatment) | !is.null(met[[2]]$treatment) | !is.null(met[[3]]$treatment)) {
-      graphs[[5*(j-1) + k]] <- plot_bar(met, Dose_Level, treatment, title = paste("% Treated at Dose for", updated_model[j]), y_title = "% Treated at Dose", col = "blue", model_picked = FALSE, models = selected_models, scenarios = selected_scenarios) # Using blue for MTD
-      } else if (!is.null(met[[1]]$accuracy) | !is.null(met[[2]]$accuracy) | !is.null(met[[3]]$accuracy)) {
-      graphs[[5*(j-1) + k]] <- plot_dist(met, accuracy, ma, title = paste("Distribution of Accuracy for", updated_model[j]), x_title = "Accuracy", col = "blue", model_picked = FALSE, models = selected_models, scenarios = selected_scenarios) # Using blue for mean
+      graphs[[4*(j-1) + k]] <- plot_bar(met, Dose_Level, treatment, title = paste("% Treated at Dose for", updated_model[j]), y_title = "% Treated at Dose", col = "blue", model_picked = FALSE, models = selected_models, scenarios = selected_scenarios) # Using blue for MTD
       } else if (!is.null(met[[1]]$overdose) | !is.null(met[[2]]$overdose) | !is.null(met[[3]]$overdose)) {
-      graphs[[5*(j-1) + k]] <- plot_dist(met, overdose, mo, title = paste("Distribution of Overdoses for", updated_model[j]), x_title = "Overdose", col = "blue", model_picked = FALSE, models = selected_models, scenarios = selected_scenarios) # Using blue for mean
+      graphs[[4*(j-1) + k]] <- plot_dist(met, overdose, mo, title = paste("Distribution of Overdoses for", updated_model[j]), x_title = "Overdose", col = "blue", model_picked = FALSE, models = selected_models, scenarios = selected_scenarios) # Using blue for mean
       } else if (!is.null(met[[1]]$length) | !is.null(met[[2]]$length) | !is.null(met[[3]]$length)) {
-      graphs[[5*(j-1) + k]] <- plot_dist(met, length, ml, title = paste("Distribution of Trial Duration for", updated_model[j]), x_title = "Trial Duration", col = "blue", model_picked = FALSE, models = selected_models,  scenarios = selected_scenarios) # Using blue for mean
+      graphs[[4*(j-1) + k]] <- plot_dist(met, length, ml, title = paste("Distribution of Trial Duration for", updated_model[j]), x_title = "Trial Duration", col = "blue", model_picked = FALSE, models = selected_models,  scenarios = selected_scenarios) # Using blue for mean
       } else {
-        graphs[[5*(j-1) + k]] <- NULL 
+        graphs[[4*(j-1) + k]] <- NULL
       } # Using fixed values for means for now
     }
    }

--- a/app_skeleton/pages/sim_ui.R
+++ b/app_skeleton/pages/sim_ui.R
@@ -109,8 +109,14 @@ ns <- session$ns
   n_scenarios <- reactive({as.numeric(input$n_scenarios_input)})
 
   ############## Reactive True DLT Probabilities Table ##############
+ 
+  scen_1_init <- c(1, example_scenarios(0.3, 3, 0.05, 5, 1))
+  scen_2_init <- c(2, example_scenarios(0.3, 3, 0.05, 5, 2))
+  scen_3_init <- c(3, example_scenarios(0.3, 3, 0.05, 5, 3))
+  matrix <- rbind(scen_1_init, scen_2_init, scen_3_init)
+  colnames(matrix) <- list("Scenario", "d1", "d2", "d3", "d4", "d5")
 
-  reactive_df <- reactiveVal() # initalising a reactive value to store the data frame
+  reactive_df <- reactiveVal(matrix) # initalising a reactive value to store the data frame
 
   observeEvent({input$refresh_table_input}, {
 
@@ -138,7 +144,7 @@ ns <- session$ns
   })
   
   output$test_df <- renderDT({
-    datatable(reactive_df(), editable = TRUE, rownames = FALSE) 
+    datatable(reactive_df(), editable = TRUE, rownames = FALSE, options = list(scrollX = TRUE)) 
   })
   
   # Observe the cell edits in the datatable

--- a/app_skeleton/pages/sim_ui.R
+++ b/app_skeleton/pages/sim_ui.R
@@ -38,11 +38,7 @@ sim_ui <- function(id) {
           nav_panel(
             "Simulation Output - Tables",
             h3("Simulation Output - Tables"),
-            p("Below are two cards containing the same table outputs. Scroll within each card to see tables side by side."),
-            layout_column_wrap( 
-            card(height = 400, card_header("Comparison Card 1"), uiOutput(ns("tables1"))),
-            card(height = 400, card_header("Comparison Card 2"), uiOutput(ns("tables2")))
-            )
+            uiOutput(ns("tables_ui"))
           ),
           nav_panel("Simulation Output - Plots",
           h3("Simulation Output - Plots"),
@@ -353,8 +349,10 @@ ns <- session$ns
   }) 
 
   tables_and_titles <- renderUI({ generate_tables_ui })
-  output$tables1 <- tables_and_titles
-  output$tables2 <- tables_and_titles
+
+  if ("Individually" %in% input$comparative_view) {
+    output$tables_ui <- tables_and_titles
+  } else {output$tables_ui <- NULL}
 
   ########################## Plots #####################################
 

--- a/app_skeleton/pages/sim_ui.R
+++ b/app_skeleton/pages/sim_ui.R
@@ -114,7 +114,18 @@ ns <- session$ns
 
   observeEvent({input$refresh_table_input}, {
 
-  dimensions <- matrix(0, nrow = n_scenarios(), ncol = shared$n_dosess())
+  ex_scen_1 <- example_scenarios(shared$ttl(), shared$prior_mtd_crm(), 0.05, shared$n_dosess(), 1)
+  ex_scen_2 <- example_scenarios(shared$ttl(), shared$prior_mtd_crm(), 0.05, shared$n_dosess(), 2)
+  ex_scen_3 <- example_scenarios(shared$ttl(), shared$prior_mtd_crm(), 0.05, shared$n_dosess(), 3)
+
+  if (n_scenarios() == 1) {
+    dimensions <- ex_scen_1
+  } else if (n_scenarios() == 2) {
+    dimensions <- rbind(ex_scen_1, ex_scen_2)
+  } else if (n_scenarios() == 3) {
+    dimensions <- rbind(ex_scen_1, ex_scen_2, ex_scen_3)
+  }
+
   colnames(dimensions) <- paste("d", 1:shared$n_dosess(), sep = "")
   dataframe <- data.frame(dimensions) # What was previously doses_table
 

--- a/app_skeleton/pages/sim_ui.R
+++ b/app_skeleton/pages/sim_ui.R
@@ -21,7 +21,7 @@ sim_ui <- function(id) {
   # Running the tab itself
   fluidPage(
   page_sidebar(
-      div(
+      div( 
         navset_tab(
           nav_panel(
             "Simulation Inputs", 
@@ -46,13 +46,6 @@ sim_ui <- function(id) {
           ),
           nav_panel("Simulation Output - Plots",
           h3("Simulation Output - Plots"),
-          card(
-            card_header("How do you want to Compare Results?"),
-            card_body(
-                      radioButtons(ns("display_plots"),"How would you like to display the simulation results?",
-                      choices = c("By Model", "By Scenario"), selected = "By Model", inline = TRUE)
-            )
-          ),
           uiOutput(ns("generate_graphs_ui"))
           )
         )
@@ -76,7 +69,13 @@ sim_ui <- function(id) {
           "Overdosing"),
         multiple = TRUE,
         list(plugins = list('remove_button'))),
-      
+
+        tags$hr(), # Separator line
+  
+        radioButtons(ns("comparative_view") , "How would you like to view the simulation results?",
+          choices = c("Individually", "Comparatively"), selected = "Comparatively", inline = TRUE),
+    
+
       #selectizeInput("visual_selection_input", "Select type of output",
         #choices = c("Table", "Plot"),
         #multiple = TRUE,
@@ -362,7 +361,7 @@ ns <- session$ns
   # Focusing on "by model" 
   metric_no_accuracy <- selected_metric[-3] # Removing accuracy from the list of selected metrics
 
-  if ("By Model" %in% input$display_plots) {
+  if ("Individually" %in% input$comparative_view) {
   graphs <- vector("list", 4*n_scen) # initialising for use later
 
    for (j in 1:n_scen) {
@@ -406,7 +405,7 @@ ns <- session$ns
     })
   })
 
-  } else if ("By Scenario" %in% input$display_plots) {
+  } else if ("Comparatively" %in% input$comparative_view) {
     # Focusing on "by scenario"
   # Adding NULLs where necessary
 

--- a/app_skeleton/pages/sim_ui.R
+++ b/app_skeleton/pages/sim_ui.R
@@ -577,10 +577,6 @@ ns <- session$ns
  current_table1 <- reactiveVal(1)
  current_table2 <- reactiveVal(2)
 
-  observeEvent(input$hehe, {
-    # This is to test the combined df
-  })
-
   observeEvent(input$next1, {
     if (current_table1() < length(sim_df())) {
       current_table1(current_table1() + 1)

--- a/app_skeleton/pages/sim_ui.R
+++ b/app_skeleton/pages/sim_ui.R
@@ -5,8 +5,8 @@ sim_ui <- function(id) {
     n_sims_input <- numericInput(ns("n_sims_input"), "How many simulations would you like to run per design per scenario?", value = 10)
     n_scenarios_input <- numericInput(ns("n_scenarios_input"), "How many scenarios would you like to simulate?", min = 1, max = 3, value = 3) # Capping the number of scenarios at 3 (for now)
 
-  n_sims_warning_text <- textOutput(ns("n_sims_warning"))
-  n_scenarios_warning_text <- textOutput(ns("n_scenarios_warning"))
+  n_sims_warning_text <- textOutput(ns("sims_warning"))
+  n_scenarios_warning_text <- textOutput(ns("scen_warning"))
   #table_output <- DT::DTOutput(ns("table_output")) # This is to test the table output used for the simulations tab.
   simulation_inputs <- tagList(
     n_sims_input,
@@ -172,6 +172,66 @@ ns <- session$ns
         multiple = TRUE, list(plugins = list('remove_button')))
     )
   })
+
+  ######## Validation ########
+
+## n_sims and n_scenarios
+
+validation_state <- reactiveValues(
+    sim_val = NULL,
+    scen_val = NULL,
+  )
+  
+  # Define base validation rules for each input
+    base_validation_rules <- list(
+    sim_val = list(min_val = 1, max_val = NULL, integer_only = TRUE),
+    scen_val = list(min_val = 1, max_val = 3, integer_only = TRUE)
+    )
+   
+  validation_rules <- reactive({base_validation_rules})
+
+  # Function to update validation for a specific input
+  update_validation <- function(input_id, value) {
+    rules <- validation_rules()[[input_id]]
+    error_msg <- validate_numeric_input(
+      value, 
+      min_val = rules$min_val, 
+      max_val = rules$max_val, 
+      integer_only = rules$integer_only
+    )
+    
+    validation_state[[input_id]] <- error_msg
+    
+    # Update the warning message next to the input
+    warning_id <- paste0(input_id, "_warning")
+    if (is.null(error_msg)) {
+      validation_state[[warning_id]] <- ""
+    } else {
+      validation_state[[warning_id]] <- paste("⚠️", error_msg)
+    }
+  }
+  
+  # Observe changes in each input and validate
+
+  observe({
+    update_validation("sim_val", input$n_sims_input)
+  })
+
+  observe({
+    update_validation("scen_val", input$n_scenarios_input)
+  })
+  
+  
+  # Render individual warning messages next to each input
+  output$sims_warning <- renderText({
+    validation_state$sim_val_warning %||% ""
+  })
+
+   output$scen_warning <- renderText({
+    validation_state$scen_val_warning %||% ""
+  })
+
+  
 
  ######################################### Simulation Outputs #########################################
  # Code copied directly from the trial_design tab's server code

--- a/app_skeleton/pages/sim_ui.R
+++ b/app_skeleton/pages/sim_ui.R
@@ -116,8 +116,9 @@ ns <- session$ns
   scen_3_init <- c(3, example_scenarios(0.3, 3, 0.05, 5, 3))
   matrix <- rbind(scen_1_init, scen_2_init, scen_3_init)
   colnames(matrix) <- list("Scenario", "d1", "d2", "d3", "d4", "d5")
+  matrix_df <- as.data.frame(matrix)
 
-  reactive_df <- reactiveVal(matrix) # initalising a reactive value to store the data frame
+  reactive_df <- reactiveVal(matrix_df) # initalising a reactive value to store the data frame
 
   observeEvent({input$refresh_table_input}, {
 

--- a/app_skeleton/pages/sim_ui.R
+++ b/app_skeleton/pages/sim_ui.R
@@ -33,7 +33,8 @@ sim_ui <- function(id) {
             in the table below. If the dimensions do not match, change the number of scenarios and doses and press 
             'Refresh Dimensions'."),
             test_df_table,
-            input_task_button(ns("refresh_table_input"), "Refresh Table Dimensions")
+            input_task_button(ns("refresh_table_input"), "Refresh Table Dimensions"),
+            textOutput(ns("table_warning"))
             ),
           nav_panel(
             "Simulation Output - Tables",
@@ -231,7 +232,31 @@ validation_state <- reactiveValues(
     validation_state$scen_val_warning %||% ""
   })
 
-  
+  ## The reactive table
+  observeEvent(input$test_df_cell_edit, {
+  if (any(is.na(reactive_df()))) {
+    output$table_warning <- renderText({
+      "⚠️ Please ensure all cells in the True DLT probabilities table are filled out before running the simulation."
+    })
+  } else if (any(reactive_df()[, -1] < 0 | reactive_df()[, -1] > 1)) {
+    output$table_warning <- renderText({
+      "⚠️ Please ensure all True DLT probabilities are between 0 and 1."
+    })
+  } else { incr_val <- rep(FALSE, nrow(reactive_df()))
+    for (i in 1: nrow(reactive_df())) {
+    if (is.unsorted(reactive_df()[i, -1])) {
+      incr_val[i] <- TRUE
+    } 
+  }
+  if (any(incr_val)) {
+    output$table_warning <- renderText({
+        "⚠️ Please ensure all rows of the table contain an increasing sequence of true DLT probabilities."
+      })
+  } else {
+    output$table_warning <- NULL
+  }
+  }
+  })
 
  ######################################### Simulation Outputs #########################################
  # Code copied directly from the trial_design tab's server code

--- a/app_skeleton/pages/trial_design_ui.R
+++ b/app_skeleton/pages/trial_design_ui.R
@@ -333,40 +333,64 @@ trial_design_server <- function(id, shared) {
   shared$phi_1 <- 0.18
   shared$phi_2 <- 0.42
 
-  observeEvent(input$phi_1_multiple, {
-    shared$phi_1 <- as.numeric(input$phi_1_multiple) * shared$ttl()
+  observeEvent(input$ttl_multiple_phi_1, {
+    shared$phi_1 <- as.numeric(input$ttl_multiple_phi_1) * shared$ttl()
+    updateNumericInput(session, "direct_phi_1", value = shared$phi_1)
+    lambda <- boin_boundaries(target = shared$ttl(), ncohort = shared$boin_cohorts(), 
+                                 cohortsize =  shared$cohort_size(), n.earlystop = shared$stop_n_mtd_boin(), 
+                                 p.saf = shared$phi_1, p.tox = shared$phi_2)
+    updateNumericInput(session, "direct_lambda_e", value = lambda$lambda_e)
   })
-  observeEvent(input$phi_2_multiple, {
-    shared$phi_2 <- as.numeric(input$phi_2_multiple) * shared$ttl()
+  observeEvent(input$ttl_multiple_phi_2, {
+    shared$phi_2 <- as.numeric(input$ttl_multiple_phi_2) * shared$ttl()
+    updateNumericInput(session, "direct_phi_2", value = shared$phi_2)
+   lambda <- boin_boundaries(target = shared$ttl(), ncohort = shared$boin_cohorts(), 
+                                 cohortsize =  shared$cohort_size(), n.earlystop = shared$stop_n_mtd_boin(), 
+                                 p.saf = shared$phi_1, p.tox = shared$phi_2)
+    updateNumericInput(session, "direct_lambda_d", value = lambda$lambda_d)
   })
   observeEvent(input$direct_phi_1, {
     shared$phi_1 <- as.numeric(input$direct_phi_1)
+    updateNumericInput(session, "ttl_multiple_phi_1", value = shared$phi_1 / shared$ttl())
+    lambda <- boin_boundaries(target = shared$ttl(), ncohort = shared$boin_cohorts(), 
+                                 cohortsize =  shared$cohort_size(), n.earlystop = shared$stop_n_mtd_boin(), 
+                                 p.saf = shared$phi_1, p.tox = shared$phi_2)
+    updateNumericInput(session, "direct_lambda_e", value = lambda$lambda_e)
   })
   observeEvent(input$direct_phi_2, {
     shared$phi_2 <- as.numeric(input$direct_phi_2)
+    updateNumericInput(session, "ttl_multiple_phi_2", value = shared$phi_2 / shared$ttl())
+     lambda <- boin_boundaries(target = shared$ttl(), ncohort = shared$boin_cohorts(), 
+                                 cohortsize =  shared$cohort_size(), n.earlystop = shared$stop_n_mtd_boin(), 
+                                 p.saf = shared$phi_1, p.tox = shared$phi_2)
+    updateNumericInput(session, "direct_lambda_d", value = lambda$lambda_d)
   })
   observeEvent(input$lambda_e, {
-    shared$lambda_e <- as.numeric(input$direct_lambda_e)
+    shared$phi_1 <- boin_probs(shared$ttl(), as.numeric(input$lambda_e), 1)
+    updateNumericInput(session, "direct_phi_1", value = shared$phi_1)
+    updateNumericInput(session, "ttl_multiple_phi_1", value = shared$phi_1 / shared$ttl())
   })
   observeEvent(input$lambda_d, {
-    shared$lambda_d <- as.numeric(input$direct_lambda_d)
+    shared$phi_2 <- boin_probs(shared$ttl(), as.numeric(input$lambda_d), 2)
+    updateNumericInput(session, "direct_phi_2", value = shared$phi_2)
+    updateNumericInput(session, "ttl_multiple_phi_2", value = shared$phi_2 / shared$ttl())
   })
 
   observeEvent(input$boin_generate_boundaries, {
-   lambda <- BOIN::get.boundary(target = shared$ttl(), ncohort = shared$boin_cohorts(), 
+   lambda <- boin_boundaries(target = shared$ttl(), ncohort = shared$boin_cohorts(), 
                                  cohortsize =  shared$cohort_size(), n.earlystop = shared$stop_n_mtd_boin(), 
-                                 p.saf = shared$phi_1, p.tox = shared$phi_2, 0.95, FALSE, 0.05)
+                                 p.saf = shared$phi_1, p.tox = shared$phi_2)
 
-    output$boin_output_lambda_e <- renderText({ paste("lambda_e = ", lambda$lambda_e) })
-    output$boin_output_lambda_d <- renderText({ paste("lambda_d = ", lambda$lambda_d) })
+    output$boin_output_lambda_e <- renderText({ lambda$text_e })
+    output$boin_output_lambda_d <- renderText({ lambda$text_d })
   })
   observeEvent(input$boin_generate_boundaries_dir, {
-   lambda <- BOIN::get.boundary(target = shared$ttl(), ncohort = shared$boin_cohorts(), 
+   lambda <- boin_boundaries(target = shared$ttl(), ncohort = shared$boin_cohorts(), 
                                  cohortsize =  shared$cohort_size(), n.earlystop = shared$stop_n_mtd_boin(), 
-                                 p.saf = shared$phi_1, p.tox = shared$phi_2, 0.95, FALSE, 0.05)
+                                 p.saf = shared$phi_1, p.tox = shared$phi_2)
 
-    output$boin_output_lambda_e_dir <- renderText({ paste("lambda_e = ", lambda$lambda_e) })
-    output$boin_output_lambda_d_dir <- renderText({ paste("lambda_d = ", lambda$lambda_d) })
+    output$boin_output_lambda_e_dir <- renderText({ lambda$text_e })
+    output$boin_output_lambda_d_dir <- renderText({ lambda$text_d })
   })
 
 

--- a/app_skeleton/pages/trial_design_ui.R
+++ b/app_skeleton/pages/trial_design_ui.R
@@ -413,7 +413,13 @@ trial_design_server <- function(id, shared) {
     ttl_multiple_phi_1_val = NULL,
     ttl_multiple_phi_2_val = NULL,
     direct_phi_1_val = NULL,
-    direct_phi_2_val = NULL
+    direct_phi_2_val = NULL,
+
+    basic_n_doses_val = NULL,
+    basic_ttl_val = NULL,
+    basic_max_size_val = NULL,
+    basic_start_dose_val = NULL,
+    basic_cohort_val = NULL
   )
   
   # Define base validation rules for each input
@@ -435,7 +441,13 @@ trial_design_server <- function(id, shared) {
     ttl_multiple_phi_1_val = list(min_val = 0, max_val = 1, integer_only = FALSE),
     ttl_multiple_phi_2_val = list(min_val = 1, max_val = NULL, integer_only = FALSE),
     direct_phi_1_val = list(min_val = 0, max_val = 0.999, integer_only = FALSE),
-    direct_phi_2_val = list(min_val = 0, max_val = 0.999, integer_only = FALSE)
+    direct_phi_2_val = list(min_val = 0, max_val = 0.999, integer_only = FALSE),
+
+    basic_n_doses_val = list(min_val = 1, max_val = NULL, integer_only = TRUE),
+    basic_ttl_val = list(min_val = 0, max_val = 0.999, integer_only = FALSE),
+    basic_max_size_val = list(min_val = 1, max_val = NULL, integer_only = TRUE),
+    basic_start_dose_val = list(min_val = 1, max_val = NULL, integer_only = TRUE),
+    basic_cohort_val = list(min_val = 1, max_val = NULL, integer_only = TRUE)
   )
   
   ##### Dynamic validation rules
@@ -445,9 +457,15 @@ trial_design_server <- function(id, shared) {
     if (!is.null(input$n_doses_inputt) && !is.na(input$n_doses_inputt) && input$n_doses_inputt > 0) {
       rules$start_dose_val$max_val <- input$n_doses_inputt
     }
+    if (!is.null(input$basic_n_doses_inputt) && !is.na(input$basic_n_doses_inputt) && input$basic_n_doses_inputt > 0) {
+      rules$basic_start_dose_val$max_val <- input$basic_n_doses_inputt
+    }
     # cohort <= max_size
     if (!is.null(input$max_size_inputt) && !is.na(input$max_size_inputt) && input$max_size_inputt > 0) {
       rules$cohort_val$max_val <- input$max_size_inputt
+    }
+    if (!is.null(input$basic_max_size_inputt) && !is.na(input$basic_max_size_inputt) && input$basic_max_size_inputt > 0) {
+      rules$basic_cohort_val$max_val <- input$basic_max_size_inputt
     }
     # stop_n_mtd <= max_size
     if (!is.null(input$max_size_inputt) && !is.na(input$max_size_inputt) && input$max_size_inputt > 0) {
@@ -515,6 +533,13 @@ trial_design_server <- function(id, shared) {
     }
   })
   
+  observe({ 
+    update_validation("basic_n_doses_val", input$basic_n_doses_inputt)
+    if (!is.null(input$basic_start_dose_inputt)) {
+      update_validation("basic_start_dose_val", input$basic_start_dose_inputt)
+    }
+  })
+
   observe({
     update_validation("ttl_val", input$ttl_inputt)
     # When ttl changes, re-validate phi_1 and phi_2 to show warning if needed
@@ -527,6 +552,10 @@ trial_design_server <- function(id, shared) {
     if (!is.null(input$direct_phi_2)) {
       update_validation("direct_phi_2_val", input$direct_phi_2)
     }
+  })
+
+  observe({
+    update_validation("basic_ttl_val", input$basic_ttl_inputt)
   })
 
     observe({
@@ -545,13 +574,36 @@ trial_design_server <- function(id, shared) {
       update_validation("stop_n_mtd_boin_val", input$stop_n_mtd_boin)
     }
   })
+
+  observe({
+    update_validation("basic_max_size_val", input$basic_max_size_inputt)
+    # When max_size changes, re-validate cohort and stop_n_mtd to show warning if needed
+    if (!is.null(input$basic_cohort_inputt)) {
+      update_validation("basic_cohort_val", input$basic_cohort_inputt)
+    }
+  })
+
+  observe({
+    update_validation("basic_cohort_val", input$basic_cohort_inputt)
+    if (!is.null(input$basic_cohort_inputt)) {
+      update_validation("basic_cohort_val", input$basic_cohort_inputt)
+    }
+  })
   
   observe({
     update_validation("start_dose_val", input$start_dose_inputt)
   })
   
   observe({
+    update_validation("basic_start_dose_val", input$basic_start_dose_inputt)
+  })
+
+  observe({
     update_validation("cohort_val", input$cohort_inputt)
+  })
+
+  observe({
+    update_validation("basic_cohort_val", input$basic_cohort_inputt)
   })
   
   # CRM Inputs
@@ -600,20 +652,40 @@ trial_design_server <- function(id, shared) {
     validation_state$n_doses_val_warning %||% ""
   })
 
+   output$basic_n_doses_warning <- renderText({
+    validation_state$basic_n_doses_val_warning %||% ""
+  })
+
   output$ttl_warning <- renderText({
     validation_state$ttl_val_warning %||% ""
+  })
+
+  output$basic_ttl_warning <- renderText({
+    validation_state$basic_ttl_val_warning %||% ""
   })
   
   output$max_size_warning <- renderText({
     validation_state$max_size_val_warning %||% ""
   })
 
+  output$basic_max_size_warning <- renderText({
+    validation_state$basic_max_size_val_warning %||% ""
+  })
+
   output$start_dose_warning <- renderText({
     validation_state$start_dose_val_warning %||% ""
+  })
+
+  output$basic_start_dose_warning <- renderText({
+    validation_state$basic_start_dose_val_warning %||% ""
   })
   
   output$cohort_warning <- renderText({
     validation_state$cohort_val_warning %||% ""
+  })
+
+  output$basic_cohort_warning <- renderText({
+    validation_state$basic_cohort_val_warning %||% ""
   })
 
   # CRM 
@@ -681,10 +753,15 @@ trial_design_server <- function(id, shared) {
         easyClose = FALSE,
         p("Please enter your desired parameters below and click Submit to return to the app."),
         numericInput(ns("basic_n_doses_inputt"), "How many dose levels are being tested?", min = 1, value = n_doses, step = 1),
+        textOutput(ns("basic_n_doses_warning")),
         numericInput(ns("basic_ttl_inputt"), "What is the target toxicity level for this trial, as a decimal?", min = 0, max = 0.999, value = ttl, step = 0.01),
+        textOutput(ns("basic_ttl_warning")),
         numericInput(ns("basic_max_size_inputt"), "What is the maximum sample size for this trial?", min = 1, value = max_size, step = 1),
+        textOutput(ns("basic_max_size_warning")),
         numericInput(ns("basic_start_dose_inputt"), "What is the starting dose level?", min = 1, value = start_dose, step = 1),
+        textOutput(ns("basic_start_dose_warning")),
         numericInput(ns("basic_cohort_inputt"), "What size will the cohorts be?", min = 1, value = cohort, step = 1),
+        textOutput(ns("basic_cohort_warning")),
         radioButtons(ns("basic_skip_esc_input"),"Would you like to be able to skip doses when escalating? (For CRM models only)",
           choices = c("Yes" = TRUE, "No" = FALSE), selected = FALSE, inline = TRUE),
         radioButtons(ns("basic_skip_deesc_input"),"Would you like to be able to skip doses when de-escalating? (For CRM and 3+3 models only)",

--- a/app_skeleton/pages/trial_design_ui.R
+++ b/app_skeleton/pages/trial_design_ui.R
@@ -140,7 +140,8 @@ choices = c("Enter the toxicity probability threshold as a multiple of the targe
 
 
   page_sidebar( 
-      
+      p("Prefer to control only the basic parameters? Click here."),
+      actionButton(ns("basic_mode"), "Basic Mode"),
    
    # General Trial Design Parameters
      layout_column_wrap(  
@@ -198,9 +199,11 @@ choices = c("Enter the toxicity probability threshold as a multiple of the targe
 
 trial_design_server <- function(id, shared) {
   moduleServer(id, function(input, output, session) {
+    ns <- session$ns
 
 ################## Questionnaire Inputs ##################    
-# Transfer logic removed - now handled in questionnaire modal navigation
+# Logic needs to be added from orgin/dev.
+
 
     #################################### From Configurations Tab Server #####################################
 
@@ -532,6 +535,53 @@ trial_design_server <- function(id, shared) {
 
   output$stop_tox_y_warning <- renderText({
     validation_state$stop_tox_y_val_warning %||% ""
+  })
+
+  ################################ Basic Mode ################################
+
+  observeEvent(input$basic_mode, {
+
+    n_doses <- shared$n_dosess()
+    ttl <- shared$ttl()
+    max_size <- shared$max_size()
+    start_dose <- shared$start_dose()
+    cohort <- shared$cohort_size()
+    
+    shiny::showModal(
+      modalDialog( 
+        title = "Trial Design - Basic Mode",
+        size = 'l',
+        easyClose = FALSE,
+        p("Please enter your desired parameters below and click Submit to return to the app."),
+        numericInput(ns("basic_n_doses_inputt"), "How many dose levels are being tested?", min = 1, value = n_doses, step = 1),
+        numericInput(ns("basic_ttl_inputt"), "What is the target toxicity level for this trial, as a decimal?", min = 0, max = 0.999, value = ttl, step = 0.01),
+        numericInput(ns("basic_max_size_inputt"), "What is the maximum sample size for this trial?", min = 1, value = max_size, step = 1),
+        numericInput(ns("basic_start_dose_inputt"), "What is the starting dose level?", min = 1, value = start_dose, step = 1),
+        numericInput(ns("basic_cohort_inputt"), "What size will the cohorts be?", min = 1, value = cohort, step = 1),
+        radioButtons(ns("basic_skip_esc_input"),"Would you like to be able to skip doses when escalating? (For CRM models only)",
+          choices = c("Yes" = TRUE, "No" = FALSE), selected = FALSE, inline = TRUE),
+        radioButtons(ns("basic_skip_deesc_input"),"Would you like to be able to skip doses when de-escalating? (For CRM and 3+3 models only)",
+          choices = c("Yes" = TRUE, "No" = FALSE), selected = FALSE, inline = TRUE),
+        footer = tagList(
+          modalButton("Cancel"),
+          actionButton(ns("submit_basic_mode"), "Submit")
+        )
+      )
+    )
+  })
+
+  observeEvent(input$submit_basic_mode, {
+    # Update shared variables with basic mode inputs
+    updateNumericInput(session, "n_doses_inputt", value = input$basic_n_doses_inputt)
+    updateNumericInput(session, "ttl_inputt", value = input$basic_ttl_inputt)
+    updateNumericInput(session, "max_size_inputt", value = input$basic_max_size_inputt)
+    updateNumericInput(session, "start_dose_inputt", value = input$basic_start_dose_inputt)
+    updateNumericInput(session, "cohort_inputt", value = input$basic_cohort_inputt)
+    updateRadioButtons(session, "skip_esc_crm_input", selected = input$basic_skip_esc_input)
+    updateRadioButtons(session, "skip_deesc_crm_input", selected = input$basic_skip_deesc_input)
+    updateRadioButtons(session, "skip_tpt_input", selected = input$basic_skip_deesc_input)
+
+    removeModal()
   })
 
 } # End of function within moduleServer

--- a/app_skeleton/pages/trial_design_ui.R
+++ b/app_skeleton/pages/trial_design_ui.R
@@ -142,13 +142,14 @@ choices = c("Enter the toxicity probability threshold as a multiple of the targe
   page_sidebar( 
       p("Prefer to control only the basic parameters? Click here."),
       actionButton(ns("basic_mode"), "Basic Mode"),
-   
+      tags$hr(),
+      h3("Trial Design - Advanced Mode"),
    # General Trial Design Parameters
      layout_column_wrap(  
      card(full_screen = TRUE,
       card_header("General Trial Parameters"),
       card_body(
-       checkboxInput("display_input_all", "Display parameters", value = F),
+       checkboxInput("display_input_all", "Display parameters", value = FALSE),
        conditionalPanel(condition = "input.display_input_all==1", non_specific_ui_inputts)
      )
       )),
@@ -158,21 +159,21 @@ choices = c("Enter the toxicity probability threshold as a multiple of the targe
         card( full_screen = TRUE,
           card_header("CRM Parameters"),
           card_body(
-           checkboxInput("display_crm", "Display parameters", value = F),
+           checkboxInput("display_crm", "Display parameters", value = FALSE),
            conditionalPanel(condition = "input.display_crm==1", specific_ui_inputs_crm)
           )
         ),
         card(full_screen = TRUE,
           card_header("3+3 Parameters"),
           card_body(
-          checkboxInput("display_tpt", "Display parameters", value = F),
+          checkboxInput("display_tpt", "Display parameters", value = FALSE),
            conditionalPanel(condition = "input.display_tpt==1", skip_tpt_input)
           )
         ),
         card(full_screen = TRUE,
           card_header("BOIN Parameters"),
           card_body(
-            checkboxInput("display_boin", "Display parameters", value = F),
+            checkboxInput("display_boin", "Display parameters", value = FALSE),
            conditionalPanel(condition = "input.display_boin == 1", boin_input_choice, tags$hr()),
            conditionalPanel(condition = "input.display_boin == 1 && input.boin_input_choice == 1", boin_ui_inputs_multiple_ttl),
            conditionalPanel(condition = "input.display_boin == 1 && input.boin_input_choice == 2", boin_ui_inputs_direct_tox_prob),
@@ -550,7 +551,7 @@ trial_design_server <- function(id, shared) {
     shiny::showModal(
       modalDialog( 
         title = "Trial Design - Basic Mode",
-        size = 'l',
+        size = 'xl',
         easyClose = FALSE,
         p("Please enter your desired parameters below and click Submit to return to the app."),
         numericInput(ns("basic_n_doses_inputt"), "How many dose levels are being tested?", min = 1, value = n_doses, step = 1),

--- a/app_skeleton/pages/trial_design_ui.R
+++ b/app_skeleton/pages/trial_design_ui.R
@@ -45,7 +45,7 @@ choices = c("Yes" = TRUE, "No" = FALSE), selected = TRUE, inline = TRUE)
 prior_var_input <- numericInput(ns("prior_var_input"), "What is the estimate of the prior variance?", min = 0, value = 0.1)
 stop_n_mtd_input <- numericInput(ns("stop_n_mtd_input"), "What is the minimum number of patients required at recommended dose before early stopping?", min = 1, value = 24)
 skeleton_input <- textInput(ns("skeleton_input"), "What are the prior estimates of the DLT rates at each dose? Please make this an increasing list and separate each value with a comma.", value = "0.108321683015674,0.255548628279939,0.425089891767129,0.576775912195444,0.817103320499882")
-prior_mtd_input <- numericInput(ns("prior_mtd_input"), "What is your prior guess of the MTD?", min = 1, value = 8)
+prior_mtd_input <- numericInput(ns("prior_mtd_input"), "What is your prior guess of the MTD?", min = 1, value = 3)
 stop_tox_x_input <- numericInput(ns("stop_tox_x_input"), "When using the this Bayesian safety early criterion: p(true DLT rate at lowest dose > target DLT rate + x | data) > y, what would you like x to be? This is the excess toxicity above the target DLT.", min = 0, value = 0.09)
 stop_tox_y_input <- numericInput(ns("stop_tox_y_input"), "What would you like y to be? This is the confidence level for safety stopping.", min = 0, max = 1, value = 0.77)
 


### PR DESCRIPTION
This branch contains some of the fixes to the issues in PR #67. These being (copied directly from the PR):

1. In the Trial Designs tab, there is a button to generate escalation boundaries for the BOIN data. It doesn't do anything currently, so that needs to be added. 
2. The accuracy distribution plots don't actually plot accuracy, but instead a similar plot to % of simulations that chose a dose as the MTD. This needs to be reworked (at the simulation level as the simulation functions themselves are the issue).
3. The tables display rework doesn't work, as the tables do not appear on the right comparison card. How to present the tables needs to be thought about, and if it is decided that we should stick with the current format, then the right comparison card needs to be fixed.
4. The pattern labels on the bar charts don't work.
5. A method to download possible plots and tables needs to be added.
6.  A method to upload and download trial design responses needs to be added.
7.  Validation needs to be added to some of the trial design inputs and all of the simulation inputs.
8. When writing the 'by Scenarios' part of the plots, I came across a bug that required me to change most of the previous code. As a result, the finished code without the bug is lengthier than it could/should be, so it needs to be cut down.

Point 1. was solved in the previous PR, but was broken. It has been fixed in this PR.
Points 2-3 have been solved in this PR. 
Points 4-8 still need to be solved. Some further validation has been added (namely to the BOIN inputs in Trial Designs).

Further to these issues, this PR has restructured the Simulations tab:
- As discussed in the meeting last week, I have changed the views to Individual and Comparative, which can be chosen in the sidebar.
- Individual view outputs the tables in a list as before, and outputs the plots by model.
- Comparative view outputs two tables with next and previous buttons. Clicking those buttons allows the user to move through the tables so that they can compare any two at once. The plot output is by scenario.
- (To solve problem 2) on further investigation, it turned out the Accuracy plot was identical to the % MTD plot, so it has been removed. Selecting Accuracy now only displays the mean accuracy in the Table output.
- The overview and length plots are now density plots, with dotted lines as medians instead of means.
- The scenario table now has 'default values' based on different CRM skeleton models. 
- Changes have been made to the BOIN inputs in Trial Designs to fix multiple bugs in the previous PR.
- A Basic Mode has been added to the Trial Designs tab, which can be access by pressing the 'Basic Mode' button.

To test this PR, see PR #67. This PR should be tested and approved first as it fixes several issues in PR #67.