### PR TITLE
Improve Basic Mode Implementation with Toggle-Based Parameter Hiding & Persistence (WIP)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "r.rterm.linux": "/home/xlai/miniconda3/envs/dosefinderhub/bin/R",
+    "r.rpath.linux": "/home/xlai/miniconda3/envs/dosefinderhub/bin/R"
+}

--- a/app_skeleton/pages/trial_design_ui.R
+++ b/app_skeleton/pages/trial_design_ui.R
@@ -138,7 +138,6 @@ boin_ui_inputs_direct_boundaries <- tagList(
   direct_lambda_d
 )
 
-# Basic mode inputs integrated into main parameter system - no separate basic_* inputs needed
 
 
 ########################################### Running the UI ###########################################
@@ -767,7 +766,11 @@ observeEvent(move_data(), {
     }
   })
 
-
+  observeEvent(input$advanced_mode, {
+    if (!is.null(input$prior_mtd_input)) {
+      updateNumericInput(session, "prior_mtd_input", value = input$prior_mtd_input)
+    }
+  })
 
   # This is clunky - needs to be changed to be more elegant.
   observeEvent(input$n_doses_inputt, {


### PR DESCRIPTION
This partially addressed #78. advanced mode is working as it should, and the value updated in advanced mode will be transfer to basic mode (prior_mtd_guess). However the two radio buttons for escalation/de-escalation not working, and transferring from basic to advance is not displaying correctly either even though the value clearly is updated. This can be checked  by entering an invalid value in basic mode and switch to advanced mode to check if the number is indeed invalid.

welcome any fixes if you can find one.